### PR TITLE
Propagates generator exit code to the parent NodeJS process

### DIFF
--- a/bin/openapi-generator
+++ b/bin/openapi-generator
@@ -14,3 +14,4 @@ if (args) {
 const cmd = exec(command);
 cmd.stdout.pipe(process.stdout);
 cmd.stderr.pipe(process.stderr);
+cmd.on('exit', process.exit)


### PR DESCRIPTION
It is necessary to detect generator failures from parent scripts, if
any.