### PR TITLE
Fixes shell buffer overflow for large input specs

### DIFF
--- a/bin/openapi-generator
+++ b/bin/openapi-generator
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const {exec} = require('child_process');
+const {spawn} = require('child_process');
 const {resolve} = require('path');
 
 const args = process.argv.slice(2);
@@ -13,7 +13,5 @@ if (args) {
     command += ` ${args.join(' ')}`;
 }
 
-const cmd = exec(command);
-cmd.stdout.pipe(process.stdout);
-cmd.stderr.pipe(process.stderr);
+const cmd = spawn(command, { stdio: 'inherit', shell: true });
 cmd.on('exit', process.exit);


### PR DESCRIPTION
The `exec()` function buffers the output of the command executed.
When using a large input spec (over 20k lines), the process is terminated due to overflowing the buffer.

Increasing the buffer also fixes the issue, but for a generic solution, `spawn()` pipes the output directly without buffering, and behaves just the same with the option `shell: true`.

To replicate the error, run `exec(command, { maxBuffer: 1000 })` on the [petstore example](https://github.com/OAI/OpenAPI-Specification/blob/master/examples/v3.0/petstore.yaml).

More info on https://medium.freecodecamp.org/node-js-child-processes-everything-you-need-to-know-e69498fe970a.