### PR TITLE
Expose batch and other hidden commands

### DIFF
--- a/apps/generator-cli/src/app/services/pass-trough.service.ts
+++ b/apps/generator-cli/src/app/services/pass-trough.service.ts
@@ -20,11 +20,9 @@ export class PassTroughService {
 
   public async init() {
 
-    (await this.help())
+    (await this.completion())
       .split('\n')
-      .filter(line => startsWith(line, ' '))
       .map(trim)
-      .map(line => line.match(/^([a-z-]+)\s+(.+)/i).slice(1))
       .forEach(([command, desc]) => {
         this.program.command(command).allowUnknownOption().description(desc).action(async (cmd: Command) => {
 
@@ -55,8 +53,8 @@ export class PassTroughService {
     shell: true
   }).on('exit', process.exit);
 
-  private help = () => new Promise<string>((resolve, reject) => {
-    exec(`${this.cmd()} help`, (error, stdout, stderr) => {
+  private completion = () => new Promise<string>((resolve, reject) => {
+    exec(`${this.cmd()} completion`, (error, stdout, stderr) => {
       error ? reject(new Error(stderr)) : resolve(stdout)
     })
   });


### PR DESCRIPTION
When you use the very usefull `batch` subcommand you can't because it not appears in jar `help`.
Nevermind it's more safe to use the `completion` command in place of `help` for pass-through service.

Exemple of batch command :
https://openapi-generator.tech/docs/usage/#batch