### PR TITLE
feat(core): add opencollective to to show sponsorship message

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
   "homepage": "https://github.com/OpenAPITools/openapi-generator-cli",
   "bugs": "https://github.com/OpenAPITools/openapi-generator-cli/issues",
   "readme": "README.md",
+  "funding": {
+    "type": "opencollective",
+    "url": "https://https://opencollective.com/openapi_generator"
+  },
   "repository": {
     "type": "git",
     "url": "git@github.com:OpenAPITools/openapi-generator-cli.git"
@@ -69,9 +73,18 @@
     "workspace-schematic": "nx workspace-schematic",
     "dep-graph": "nx dep-graph",
     "help": "nx help",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release",
+    "postinstall": "opencollective || exit 0"
+  },
+  "collective": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/openapi_generator",
+    "donation": {
+      "text": "Please sponsor OpenAPI Generator."
+    }
   },
   "dependencies": {
+    "@nuxtjs/opencollective": "0.2.2",
     "@nestjs/common": "7.4.4",
     "@nestjs/core": "7.4.4",
     "@nestjs/platform-express": "7.4.4",


### PR DESCRIPTION
The message looks like this:
```
npm install

> openapitools@0.0.0-development postinstall /Users/williamcheng/Code/openapi-generator-cli
> opencollective || exit 0

                    Thanks for installing openapi_generator 🙏
                 Please consider donating to our open collective
                        to help us maintain this package.
                                         
                            Number of contributors: 0
                              Number of backers: 18
                              Annual budget: $5,332
                             Current balance: $3,257
                                         
 👉  Please sponsor OpenAPI Generator. https://opencollective.com/openapi_generator/donate
                                         
npm WARN @nestjs/schematics@7.1.2 requires a peer of typescript@^3.4.5 but none is installed. You must install peer dependencies yourself.
npm WARN jsdom@16.4.0 requires a peer of canvas@^2.5.0 but none is installed. You must install peer dependencies yourself.
npm WARN jsdom@15.2.1 requires a peer of canvas@^2.5.0 but none is installed. You must install peer dependencies yourself.
npm WARN ws@7.3.1 requires a peer of bufferutil@^4.0.1 but none is installed. You must install peer dependencies yourself.
npm WARN ws@7.3.1 requires a peer of utf-8-validate@^5.0.2 but none is installed. You must install peer dependencies yourself.

audited 2337 packages in 87.238s
found 1 low severity vulnerability
  run `npm audit fix` to fix them, or `npm audit` for details

```