### PR TITLE
feat: allow concurrent downloads by downloading file and moving it

### DIFF
--- a/apps/generator-cli/src/app/services/version-manager.service.spec.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.spec.ts
@@ -377,6 +377,7 @@ describe('VersionManagerService', () => {
 
         beforeEach(async () => {
           data.pipe.mockReset();
+          fs.mkdtempSync.mockReset().mockReturnValue('/tmp/generator-cli-abcDEF');
           fs.ensureDirSync.mockReset();
           fs.createWriteStream.mockReset().mockReturnValue(file);
 
@@ -439,8 +440,17 @@ describe('VersionManagerService', () => {
             expect(fs.ensureDirSync).toHaveBeenNthCalledWith(1, fixture.storage);
           });
 
+
+          it('creates a temporary directory', () => {
+            expect(fs.mkdtempSync).toHaveBeenNthCalledWith(1, '/tmp/generator-cli-');
+          });
+
           it('creates the correct write stream', () => {
-            expect(fs.createWriteStream).toHaveBeenNthCalledWith(1, `${fixture.storage}/4.2.0.jar`);
+            expect(fs.createWriteStream).toHaveBeenNthCalledWith(1, '/tmp/generator-cli-abcDEF/4.2.0');
+          });
+
+          it('moves the file to the target location', () => {
+            expect(fs.moveSync).toHaveBeenNthCalledWith(1, '/tmp/generator-cli-abcDEF/4.2.0', `${fixture.storage}/4.2.0.jar`);
           });
 
           it('receives the data piped', () => {

--- a/apps/generator-cli/src/app/services/version-manager.service.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.ts
@@ -111,9 +111,14 @@ export class VersionManagerService {
         .get<Stream>(downloadLink, { responseType: 'stream' })
         .pipe(switchMap(res => new Promise(resolve => {
             fs.ensureDirSync(this.storage);
-            const file = fs.createWriteStream(filePath);
+            const temporaryDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'generator-cli-'));
+            const temporaryFilePath = path.join(temporaryDirectory, versionName);
+            const file = fs.createWriteStream(temporaryFilePath);
             res.data.pipe(file);
-            file.on('finish', resolve);
+            file.on('finish', content => {
+              fs.moveSync(temporaryFilePath, filePath);
+              resolve(content);
+            });
           })
         )).toPromise();
 


### PR DESCRIPTION
This pull request allows the version manager to download multiple files concurrently of the same version. Currently, doing so corrupts the file because the downloaded stream overwrites the partially downloaded file of the other process.

Also see issue #188, which was closed.

The workaround presented in the issue is only a workaround and not a fix. The request to re-open the issue was unanswered, so I created a pull request instead.