### PR TITLE
fix: add overwrite: true to overwrite on existing file

### DIFF
--- a/apps/generator-cli/src/app/services/version-manager.service.spec.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.spec.ts
@@ -1,14 +1,14 @@
-import {Test} from '@nestjs/testing';
-import {Version, VersionManagerService} from './version-manager.service';
-import {HttpService} from '@nestjs/common';
-import {of} from 'rxjs';
-import {mocked} from 'ts-jest/utils';
-import {LOGGER} from '../constants';
+import { Test } from '@nestjs/testing';
+import { Version, VersionManagerService } from './version-manager.service';
+import { HttpService } from '@nestjs/common';
+import { of } from 'rxjs';
+import { mocked } from 'ts-jest/utils';
+import { LOGGER } from '../constants';
 import * as chalk from 'chalk';
-import {ConfigService} from './config.service';
-import {resolve} from 'path';
+import { ConfigService } from './config.service';
+import { resolve } from 'path';
 import * as os from 'os';
-import {TestingModule} from '@nestjs/testing/testing-module';
+import { TestingModule } from '@nestjs/testing/testing-module';
 
 jest.mock('fs-extra');
 // eslint-disable-next-line @typescript-eslint/no-var-requires

--- a/apps/generator-cli/src/app/services/version-manager.service.spec.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.spec.ts
@@ -1,14 +1,14 @@
-import { Test } from '@nestjs/testing';
-import { Version, VersionManagerService } from './version-manager.service';
-import { HttpService } from '@nestjs/common';
-import { of } from 'rxjs';
-import { mocked } from 'ts-jest/utils';
-import { LOGGER } from '../constants';
+import {Test} from '@nestjs/testing';
+import {Version, VersionManagerService} from './version-manager.service';
+import {HttpService} from '@nestjs/common';
+import {of} from 'rxjs';
+import {mocked} from 'ts-jest/utils';
+import {LOGGER} from '../constants';
 import * as chalk from 'chalk';
-import { ConfigService } from './config.service';
-import { resolve } from 'path';
+import {ConfigService} from './config.service';
+import {resolve} from 'path';
 import * as os from 'os';
-import { TestingModule } from '@nestjs/testing/testing-module';
+import {TestingModule} from '@nestjs/testing/testing-module';
 
 jest.mock('fs-extra');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -450,7 +450,7 @@ describe('VersionManagerService', () => {
           });
 
           it('moves the file to the target location', () => {
-            expect(fs.moveSync).toHaveBeenNthCalledWith(1, '/tmp/generator-cli-abcDEF/4.2.0', `${fixture.storage}/4.2.0.jar`);
+            expect(fs.moveSync).toHaveBeenNthCalledWith(1, '/tmp/generator-cli-abcDEF/4.2.0', `${fixture.storage}/4.2.0.jar`, {overwrite: true});
           });
 
           it('receives the data piped', () => {

--- a/apps/generator-cli/src/app/services/version-manager.service.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.ts
@@ -116,7 +116,7 @@ export class VersionManagerService {
             const file = fs.createWriteStream(temporaryFilePath);
             res.data.pipe(file);
             file.on('finish', content => {
-              fs.moveSync(temporaryFilePath, filePath);
+              fs.moveSync(temporaryFilePath, filePath, {overwrite: true});
               resolve(content);
             });
           })

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "ts-jest": "26.5.3",
     "ts-node": "9.1.1",
     "tslint": "6.1.3",
-    "type-fest": "0.21.2",
+    "type-fest": "0.21.3",
     "typescript": "4.2.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10468,10 +10468,10 @@ type-detect@4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-fest@0.21.2:
-  version "0.21.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.2.tgz#43b9dc71d9dc5593ea71bf7b0e013ec10f838249"
-  integrity sha512-pvQl0WNazvfQ0rq2XDdhpWv49sohh2t+buFbglaJ9N9+Xj4BhFRpuo+uJxemeARteRxRloJ1m+8gBR6Z2Nfktg==
+type-fest@0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
+  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
 type-fest@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
This is a followup PR of https://github.com/OpenAPITools/openapi-generator-cli/pull/295. Concurrent downloads work well, but the filesystem move call throws an error in `fs-extra` when the file already exists... It should replace it of course.

Reference documentation: https://github.com/jprichardson/node-fs-extra/blob/master/docs/move-sync.md

Sorry I did not notice it in previous testing. All the tests currently mock the filesystem library, so I cannot simulate an existing file.

Example (anonymized) output of current 2.2.0 version:
```
...
Compile the schemas /XXXXXX/har.schema.yaml to /XXXXXX
Compiling /XXXXXX/har.schema.yaml with name har.
Compile the schemas /XXXXXX/index.schema.yaml to /XXXXXX/generated
Compiling /XXXXXX/index.schema.yaml with name Index.
Compile the schemas /XXXXXX/configuration.schema.yaml to /XXXXXX/generated
Compiling /XXXXXX/configuration.schema.yaml with name BotConfiguration.
Download 5.0.1 ...
Download 5.0.1 ...
Downloaded 5.0.1
/XXXXXX/node_modules/fs-extra/lib/move-sync/move-sync.js:25
  if (fs.existsSync(dest)) throw new Error('dest already exists.')
                           ^
Error: dest already exists.
    at doRename (/XXXXXX/node_modules/fs-extra/lib/move-sync/move-sync.js:25:34)
    at Object.moveSync (/XXXXXX/node_modules/fs-extra/lib/move-sync/move-sync.js:17:10)
    at WriteStream.<anonymous> (/XXXXXX/node_modules/@openapitools/openapi-generator-cli/main.js:863:74)
    at WriteStream.emit (node:events:390:22)
    at finish (node:internal/streams/writable:741:10)
    at finishMaybe (node:internal/streams/writable:723:9)
    at afterWrite (node:internal/streams/writable:510:3)
    at onwrite (node:internal/streams/writable:483:7)
    at node:internal/fs/streams:392:5
    at FSReqCallback.wrapper [as oncomplete] (node:fs:663:5)
[main] INFO  o.o.codegen.DefaultGenerator - Generating with dryRun=false
[main] WARN  o.o.c.ignore.CodegenIgnoreProcessor - Output directory does not exist, or is inaccessible. No file (.openapi-generator-ignore) will be evaluated.
[main] INFO  o.o.codegen.DefaultGenerator - OpenAPI Generator: typescript-axios (client)
[main] INFO  o.o.codegen.DefaultGenerator - Generator 'typescript-axios' is considered stable.
[main] INFO  o.o.c.l.AbstractTypeScriptClientCodegen - Hint: Environment variable 'TS_POST_PROCESS_FILE' (optional) not defined. E.g. to format the source code, please try 'export TS_POST_PROCESS_FILE="/usr/local/bin/prettier --write"' (Linux/Mac)
...