### PR TITLE
chore: fix husky hooks

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+yarn commitlint --edit $1

--- a/package.json
+++ b/package.json
@@ -29,11 +29,6 @@
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },
-  "husky": {
-    "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
-    }
-  },
   "keywords": [
     "rest-api",
     "rest-client",


### PR DESCRIPTION
Fix broken husky hooks (since https://github.com/OpenAPITools/openapi-generator-cli/pull/316)

Converted husky v4 configuration to husky v7 config
Source: https://typicode.github.io/husky/#/?id=husky_git_params-ie-commitlint-