### PR TITLE
fix(#439): allow custom generator to be passed to the generate command

### DIFF
--- a/apps/generator-cli/src/app/services/generator.service.spec.ts
+++ b/apps/generator-cli/src/app/services/generator.service.spec.ts
@@ -128,6 +128,11 @@ describe('GeneratorService', () => {
         command: `java -jar "/path/to/4.2.1.jar" generate ${appendix.join(' ')}`,
       });
 
+      const cmdWithCustomJar = (name: string, customJar: string, appendix: string[]) => ({
+        name,
+        command: `java -cp "/path/to/4.2.1.jar:${customJar}" org.openapitools.codegen.OpenAPIGenerator generate ${appendix.join(' ')}`,
+      });
+
       describe.each([
         ['foo.json', [
           cmd('[angular] abc/app/pet.yaml', [
@@ -183,6 +188,18 @@ describe('GeneratorService', () => {
             '--some-bool',
           ]),
         ]],
+        ['bar.json', [
+          cmdWithCustomJar('[bar] api/cat.yaml', '../some/custom.jar', [
+            `--input-spec="${cwd}/api/cat.yaml"`,
+            `--output="bar/cat"`,
+            '--some-bool',
+          ]),
+          cmdWithCustomJar('[bar] api/bird.json', '../some/custom.jar', [
+            `--input-spec="${cwd}/api/bird.json"`,
+            `--output="bar/bird"`,
+            '--some-bool',
+          ]),
+        ], '../some/custom.jar'],
         ['none.json', []],
         ['also-none.json', []],
         ['no-glob.json', [
@@ -200,13 +217,13 @@ describe('GeneratorService', () => {
             `--ext="json"`,
           ]),
         ]],
-      ])('%s', (filePath, expectedCommands) => {
+      ])('%s', (filePath, expectedCommands, customGenerator) => {
 
         let returnValue: boolean
 
         beforeEach(async () => {
           configGet.mockImplementation((path, defaultValue) => config[filePath] || defaultValue)
-          returnValue = await fixture.generate()
+          returnValue = await fixture.generate(customGenerator)
         })
 
         it('calls the config get well', () => {

--- a/apps/generator-cli/src/app/services/pass-through.service.spec.ts
+++ b/apps/generator-cli/src/app/services/pass-through.service.spec.ts
@@ -190,6 +190,18 @@ describe('PassThroughService', () => {
             )
           })
 
+          if (name === 'generate') {
+            it('can delegate with custom jar to generate command', async () => {
+              await program.parseAsync([name, ...argv, '--generator-key=genKey', '--custom-generator=../some/custom.jar'], { from: 'user' })
+  
+              expect(generate).toHaveBeenNthCalledWith(
+                1,
+                '../some/custom.jar',
+                'genKey'
+              )
+            })
+          }
+
           // if (name === 'help') {
           //   it('prints the help info and does not delegate, if args length = 0', async () => {
           //     childProcess.spawn.mockReset()

--- a/apps/generator-cli/src/app/services/pass-through.service.ts
+++ b/apps/generator-cli/src/app/services/pass-through.service.ts
@@ -56,11 +56,12 @@ export class PassThroughService {
       .option("--generator-key <generator...>", "Run generator by key. Separate by comma to run many generators")
       .action(async (_, cmd) => {
         if (cmd.args.length === 0 || cmd.opts().generatorKey) {
+          const customGenerator = this.program.opts()?.customGenerator;
           const generatorKeys = cmd.opts().generatorKey || [];
 
           if (this.generatorService.enabled) {
             // @todo cover by unit test
-            if (!await this.generatorService.generate(...generatorKeys)) {
+            if (!await this.generatorService.generate(customGenerator, ...generatorKeys)) {
               this.logger.log(chalk.red('Code generation failed'));
               process.exit(1);
             }


### PR DESCRIPTION
Fixes #439 

The `custom-generator` parameter was only working for simple passthrough command, passing `custom-generator` to the generate command allows it to be used alongside `-generator-key` parameters.