### PR TITLE
Replace deprecated HttpModule from @nestjs/common with @nestjs/axios

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,13 +12,16 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ 16.x ]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js ${{matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{matrix.node-version }}
 
@@ -39,7 +42,7 @@ jobs:
           cd dist/apps/generator-cli
           yarn pack -f ../package.tgz
 
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: package.tgz
           path: dist/apps/package.tgz
@@ -51,17 +54,18 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
+        node-version: [ 16.x ]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js ${{matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{matrix.node-version }}
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         with:
           name: package.tgz
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Use Node.js ${{matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{matrix.node-version }}
 

--- a/apps/generator-cli/src/app/app.module.ts
+++ b/apps/generator-cli/src/app/app.module.ts
@@ -1,29 +1,13 @@
-import { HttpModule, Inject, Module, OnApplicationBootstrap } from '@nestjs/common';
-import { AxiosProxyConfig } from 'axios';
-import { Command } from 'commander';
-import * as url from 'url';
+import {Inject, Module, OnApplicationBootstrap} from '@nestjs/common';
+import {HttpModule} from '@nestjs/axios';
+import {Command} from 'commander';
 
-import { COMMANDER_PROGRAM, LOGGER } from './constants';
-import { VersionManagerController } from './controllers/version-manager.controller';
-import { ConfigService, GeneratorService, PassThroughService, UIService, VersionManagerService } from './services';
-
-let proxyConfig: AxiosProxyConfig;
-const proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
-
-if (proxyUrl) {
-  const proxy = url.parse(proxyUrl);
-  const proxyAuth = proxy.auth && proxy.auth.split(':');
-
-  proxyConfig = {
-    host: proxy.hostname,
-    port: parseInt(proxy.port, 10),
-    auth: proxyAuth && { username: proxyAuth[0], password: proxyAuth[1] },
-    protocol: proxy.protocol.replace(':', '')
-  };
-}
+import {COMMANDER_PROGRAM, LOGGER} from './constants';
+import {VersionManagerController} from './controllers/version-manager.controller';
+import {ConfigService, GeneratorService, PassThroughService, UIService, VersionManagerService} from './services';
 
 @Module({
-  imports: [HttpModule.register({proxy: proxyConfig})],
+  imports: [HttpModule],
   controllers: [
     VersionManagerController
   ],
@@ -37,7 +21,7 @@ if (proxyUrl) {
       provide: COMMANDER_PROGRAM,
       useValue: new Command('openapi-generator-cli').helpOption(false).usage('<command> [<args>]')
     },
-    { provide: LOGGER, useValue: console }
+    {provide: LOGGER, useValue: console}
   ]
 })
 export class AppModule implements OnApplicationBootstrap {
@@ -54,7 +38,7 @@ export class AppModule implements OnApplicationBootstrap {
     let selectedVersion = this.versionManager.getSelectedVersion();
 
     if (!selectedVersion) {
-      const [{ version }] = await this.versionManager.search(['latest']).toPromise();
+      const [{version}] = await this.versionManager.search(['latest']).toPromise();
       await this.versionManager.setSelectedVersion(version);
       selectedVersion = version;
     }

--- a/apps/generator-cli/src/app/services/version-manager.service.spec.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.spec.ts
@@ -1,6 +1,6 @@
 import { Test } from '@nestjs/testing';
 import { Version, VersionManagerService } from './version-manager.service';
-import { HttpService } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
 import { of } from 'rxjs';
 import { LOGGER } from '../constants';
 import * as chalk from 'chalk';

--- a/apps/generator-cli/src/app/services/version-manager.service.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.ts
@@ -1,4 +1,5 @@
-import {HttpService, Inject, Injectable} from '@nestjs/common';
+import {Inject, Injectable} from '@nestjs/common';
+import {HttpService} from '@nestjs/axios';
 import {catchError, map, switchMap} from 'rxjs/operators';
 import {replace} from 'lodash';
 import {Observable} from 'rxjs';

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     }
   },
   "dependencies": {
+    "@nestjs/axios": "0.0.8",
     "@nestjs/common": "8.4.4",
     "@nestjs/core": "8.4.4",
     "@nestjs/platform-express": "8.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1256,7 +1256,7 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@nestjs/axios@^0.0.8":
+"@nestjs/axios@0.0.8":
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/@nestjs/axios/-/axios-0.0.8.tgz#4e321e36b6bc3ab0f02d80bafe04ae39edfdcacf"
   integrity sha512-oJyfR9/h9tVk776il0829xyj3b2e81yTu6HjPraxynwNtMNGqZBHHmAQL24yMB3tVbBM0RvG3eUXH8+pRCGwlg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1256,6 +1256,13 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@nestjs/axios@^0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@nestjs/axios/-/axios-0.0.8.tgz#4e321e36b6bc3ab0f02d80bafe04ae39edfdcacf"
+  integrity sha512-oJyfR9/h9tVk776il0829xyj3b2e81yTu6HjPraxynwNtMNGqZBHHmAQL24yMB3tVbBM0RvG3eUXH8+pRCGwlg==
+  dependencies:
+    axios "0.27.2"
+
 "@nestjs/common@8.4.4":
   version "8.4.4"
   resolved "https://registry.yarnpkg.com/@nestjs/common/-/common-8.4.4.tgz#0914c6c0540b5a344c7c8fd6072faa1a49af1158"
@@ -2704,6 +2711,14 @@ axios@0.26.1:
   integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
   dependencies:
     follow-redirects "^1.14.8"
+
+axios@0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
 
 babel-jest@^27.2.2:
   version "27.2.5"
@@ -5245,6 +5260,11 @@ follow-redirects@^1.14.8:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
   integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
+follow-redirects@^1.14.9:
+  version "1.15.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
+  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -5278,6 +5298,15 @@ form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"


### PR DESCRIPTION
As the new axios HttpModules respects the environment variables HTTP_PROXY, HTTPS_PROXY and NO_PROXY, there is no need to configure it explicitly anymore. 

This fixes issue #390 