### PR TITLE
run docker with current user instead of root

### DIFF
--- a/apps/generator-cli/src/app/services/generator.service.ts
+++ b/apps/generator-cli/src/app/services/generator.service.ts
@@ -175,7 +175,7 @@ export class GeneratorService {
       const volumes = Object.entries(dockerVolumes).map(([k, v]) => `-v "${v}:${k}"`).join(' ');
 
       return [
-        `docker run --rm`,
+        `docker run --user $(id -u):$(id -g) --rm`,
         volumes,
         this.versionManager.getDockerImageName(),
         'generate',


### PR DESCRIPTION
Running docker containers as root is considered a security issue. Fixes #647.