### PR TITLE
Added environment variable override for storage dir

### DIFF
--- a/apps/generator-cli/src/app/services/version-manager.service.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.ts
@@ -32,7 +32,7 @@ const mvn = {
 @Injectable()
 export class VersionManagerService {
 
-  private customStorageDir = this.configService.get<string>('generator-cli.storageDir');
+  private customStorageDir = process.env.OPENAPI_GENERATOR_STORAGE_DIR || this.configService.get<string>('generator-cli.storageDir');
 
   public readonly storage = this.customStorageDir ? path.resolve(
     this.configService.cwd,


### PR DESCRIPTION
Hi!

This PR adds an environment variable override for the storageDir config. This allows easier caching of the jar file in during ci or similar. 

This is my first PR to this repo, so let me know if anything is missing!