### PR TITLE
Use agent for proxy configuration

### DIFF
--- a/apps/generator-cli/src/app/app.module.ts
+++ b/apps/generator-cli/src/app/app.module.ts
@@ -5,9 +5,20 @@ import {Command} from 'commander';
 import {COMMANDER_PROGRAM, LOGGER} from './constants';
 import {VersionManagerController} from './controllers/version-manager.controller';
 import {ConfigService, GeneratorService, PassThroughService, UIService, VersionManagerService} from './services';
+import { ProxyAgent } from 'proxy-agent';
+
+// The correct proxy `Agent` implementation to use will be determined
+// via the `http_proxy` / `https_proxy` / `no_proxy` / etc. env vars
+const agent = new ProxyAgent();
 
 @Module({
-  imports: [HttpModule],
+  imports: [
+    HttpModule.register({
+      proxy: false,
+      httpAgent: agent,
+      httpsAgent: agent
+    })
+  ],
   controllers: [
     VersionManagerController
   ],


### PR DESCRIPTION
# Motivation

HTTPS for corporate proxies doesn't work after https://github.com/OpenAPITools/openapi-generator-cli/pull/651 because it assumed that `@nestjs/axios` took care of correctly extracting proxy configuration from the environment variables. In reality, axios proxy setup is broken as mentioned in https://stackoverflow.com/a/53399378 and https://github.com/axios/axios/issues/2072#issuecomment-567473812. 

The recommended workaround is to disable axios' proxy functionality and use a proxy agent. 

# Approach

Use  [proxy-agent](https://www.npmjs.com/package/proxy-agent) to create an agent that automatically uses an appropriate proxy based on environment variables. Configure the HttpModule to use the agent. 

# TODO
- [ ] Install the dependency
- [ ] Test it to verify 