### PR TITLE
feat(#644): add cli option for openapitools.json

### DIFF
--- a/apps/generator-cli/src/app/app.module.ts
+++ b/apps/generator-cli/src/app/app.module.ts
@@ -19,7 +19,7 @@ import {ConfigService, GeneratorService, PassThroughService, UIService, VersionM
     VersionManagerService,
     {
       provide: COMMANDER_PROGRAM,
-      useValue: new Command('openapi-generator-cli').helpOption(false).usage('<command> [<args>]')
+      useValue: new Command('openapi-generator-cli').helpOption(false).usage('<command> [<args>]').option( '--openapitools <openapitools.json>', 'Use the specified openapi-generator-cli configuration file')
     },
     {provide: LOGGER, useValue: console}
   ]


### PR DESCRIPTION
This PR adds a command line argument, `--openapitools`, that allows a user to provide an `openapitools.json` file from the command line.

The current version of the cli [hardcodes](https://github.com/OpenAPITools/openapi-generator-cli/blob/720b405fd0984b6e9b510358418ea1b80ea3113b/apps/generator-cli/src/app/services/config.service.ts#L11) the location of this file. 

Should resolve at least #644.

Disclaimer, I am not a typescript developer and did my best to get a feature I (and others seem to) need :) 