### PR TITLE
fix(app): configure http with proxy url if present in environment

### DIFF
--- a/apps/generator-cli/src/app/app.module.ts
+++ b/apps/generator-cli/src/app/app.module.ts
@@ -1,16 +1,33 @@
-import {Inject, Module, OnApplicationBootstrap} from '@nestjs/common';
-import {HttpModule} from '@nestjs/axios';
-import {Command} from 'commander';
+import { Inject, Module, OnApplicationBootstrap } from '@nestjs/common';
+import { HttpModule, HttpModuleOptions } from '@nestjs/axios';
+import { Command } from 'commander';
 
-import {COMMANDER_PROGRAM, LOGGER} from './constants';
-import {VersionManagerController} from './controllers/version-manager.controller';
-import {ConfigService, GeneratorService, PassThroughService, UIService, VersionManagerService} from './services';
+import { COMMANDER_PROGRAM, LOGGER } from './constants';
+import { VersionManagerController } from './controllers/version-manager.controller';
+import {
+  ConfigService,
+  GeneratorService,
+  PassThroughService,
+  UIService,
+  VersionManagerService,
+} from './services';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+
+const proxyUrl = process.env.HTTP_PROXY || process.env.HTTPS_PROXY;
+const httpModuleConfig: HttpModuleOptions = {};
+
+if (proxyUrl) {
+  httpModuleConfig.proxy = false;
+  httpModuleConfig.httpsAgent = new HttpsProxyAgent(proxyUrl);
+}
 
 @Module({
-  imports: [HttpModule],
-  controllers: [
-    VersionManagerController
+  imports: [
+    HttpModule.register({
+      ...httpModuleConfig,
+    }),
   ],
+  controllers: [VersionManagerController],
   providers: [
     UIService,
     ConfigService,
@@ -19,26 +36,27 @@ import {ConfigService, GeneratorService, PassThroughService, UIService, VersionM
     VersionManagerService,
     {
       provide: COMMANDER_PROGRAM,
-      useValue: new Command('openapi-generator-cli').helpOption(false).usage('<command> [<args>]')
+      useValue: new Command('openapi-generator-cli')
+        .helpOption(false)
+        .usage('<command> [<args>]'),
     },
-    {provide: LOGGER, useValue: console}
-  ]
+    { provide: LOGGER, useValue: console },
+  ],
 })
 export class AppModule implements OnApplicationBootstrap {
-
   constructor(
     @Inject(COMMANDER_PROGRAM) private readonly program: Command,
     private readonly versionManager: VersionManagerService,
     private readonly passThroughService: PassThroughService
-  ) {
-  }
+  ) {}
 
   onApplicationBootstrap = async () => {
-
     let selectedVersion = this.versionManager.getSelectedVersion();
 
     if (!selectedVersion) {
-      const [{version}] = await this.versionManager.search(['latest']).toPromise();
+      const [{ version }] = await this.versionManager
+        .search(['latest'])
+        .toPromise();
       await this.versionManager.setSelectedVersion(version);
       selectedVersion = version;
     }
@@ -46,7 +64,5 @@ export class AppModule implements OnApplicationBootstrap {
     await this.versionManager.downloadIfNeeded(selectedVersion);
     await this.passThroughService.init();
     this.program.parse(process.argv);
-
   };
-
 }

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "concurrently": "6.5.1",
     "console.table": "0.10.0",
     "fs-extra": "10.1.0",
+    "https-proxy-agent": "^7.0.4",
     "inquirer": "8.2.6",
     "jsonpath": "1.1.1",
     "lodash": "4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5887,6 +5887,14 @@ https-proxy-agent@^7.0.0, https-proxy-agent@^7.0.1:
     agent-base "^7.0.2"
     debug "4"
 
+https-proxy-agent@^7.0.4:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz#8e97b841a029ad8ddc8731f26595bad868cb4168"
+  integrity sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==
+  dependencies:
+    agent-base "^7.0.2"
+    debug "4"
+
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"


### PR DESCRIPTION
This PR adjusts the `HttpModule` configuration to apply proxy configuration from the `https-proxy-agent` package if the `HTTP_PROXY` or `HTTPS_PROXY` environment variables are present.

Should Close #714 
Related to #752 (similar approach) 

## Why
_(taken from #752)_
> HTTPS for corporate proxies doesn't work after https://github.com/OpenAPITools/openapi-generator-cli/pull/651 because it assumed that @nestjs/axios took care of correctly extracting proxy configuration from the environment variables. In reality, axios proxy setup is broken as mentioned in https://stackoverflow.com/a/53399378 and https://github.com/axios/axios/issues/2072#issuecomment-567473812.