### PR TITLE
fix(#802): add fallback to default versions if search returns errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,7 @@ jobs:
           (npm run oa version-manager set 4.0 && npm run oa version | grep -q '4.0.3') || exit 1
           (npm run oa version-manager set 4.3.1 && npm run oa version | grep -q '4.3.1') || exit 1
           (npm run oa version-manager set 4.3.1 && npm run oa version | grep -q '4.3.1') || exit 1
+          (export OPENAPI_GENERATOR_CLI_SEARCH_URL=DEFAULT && npm run oa version-manager set 7.2.0 && npm run oa version | grep -q '7.2.0') || exit 1
           json -I -f openapitools.json -e 'this["generator-cli"]["storageDir"]="./my/storage/"'
           (npm run oa version-manager set 4.3.0 && npm run oa version | grep -q '4.3.0') || exit 1
           test -f ./my/storage/4.3.0.jar || exit 1

--- a/apps/generator-cli/src/app/services/version-manager.service.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import { HttpService } from '@nestjs/axios';
 import { catchError, map, switchMap } from 'rxjs/operators';
 import { replace } from 'lodash';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { AxiosError } from 'axios';
 import * as fs from 'fs-extra';
 import * as path from 'path';
@@ -46,9 +46,23 @@ export class VersionManagerService {
     @Inject(LOGGER) private readonly logger: LOGGER,
     private httpService: HttpService,
     private configService: ConfigService
-  ) {}
+  ) {
+    // pre-process intsalled in versions
+    this.versions.forEach( (item) => {
+      item.installed = this.isDownloaded(item.version)
+    });
+  }
+
+  getObservableVersions(): Observable<Version[]> {
+    return of(this.versions);
+  }
 
   getAll(): Observable<Version[]> {
+    // bypass querying serach.maven.org and use default versions instead
+    if (process.env.OPENAPI_GENERATOR_CLI_SEARCH_URL === 'DEFAULT' ) {
+      return this.getObservableVersions();
+    }
+
     const queryUrl = this.replacePlaceholders(
       this.configService.get<string>('generator-cli.repository.queryUrl') ||
         configSchema.properties['generator-cli'].properties.repository.queryUrl
@@ -80,10 +94,10 @@ export class VersionManagerService {
       }),
       catchError((e) => {
         this.logger.log(
-          chalk.red(`Unable to query repository, because of: "${e.message}"`)
+          chalk.red(`Unable to query repository, because of: "${e.message}". Return default versions instead.`)
         );
         this.printResponseError(e);
-        return [];
+        return this.getObservableVersions();
       })
     );
   }
@@ -267,4 +281,469 @@ export class VersionManagerService {
   public filePath(versionName = this.getSelectedVersion()) {
     return path.resolve(this.storage, `${versionName}.jar`);
   }
+
+  versions : Version[] = [
+    {
+      version: '7.8.0',
+      versionTags: [ '7.8.0', 'stable', 'latest' ],
+      releaseDate: new Date("2024-08-19T06:24:58.285Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.8.0/openapi-generator-cli-7.8.0.jar'
+    },
+    {
+      version: '7.7.0',
+      versionTags: [ '7.7.0', 'stable' ],
+      releaseDate: new Date("2024-07-02T08:03:44.452Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.7.0/openapi-generator-cli-7.7.0.jar'
+    },
+    {
+      version: '7.6.0',
+      versionTags: [ '7.6.0', 'stable' ],
+      releaseDate: new Date("2024-05-20T09:07:21.579Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.6.0/openapi-generator-cli-7.6.0.jar'
+    },
+    {
+      version: '7.5.0',
+      versionTags: [ '7.5.0', 'stable' ],
+      releaseDate: new Date("2024-04-17T08:42:14.968Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.5.0/openapi-generator-cli-7.5.0.jar'
+    },
+    {
+      version: '7.4.0',
+      versionTags: [ '7.4.0', 'stable' ],
+      releaseDate: new Date("2024-03-11T02:28:09.325Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.4.0/openapi-generator-cli-7.4.0.jar'
+    },
+    {
+      version: '7.3.0',
+      versionTags: [ '7.3.0', 'stable' ],
+      releaseDate: new Date("2024-02-08T07:39:15.042Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.3.0/openapi-generator-cli-7.3.0.jar'
+    },
+    {
+      version: '7.2.0',
+      versionTags: [ '7.2.0', 'stable' ],
+      releaseDate: new Date("2023-12-22T07:12:33.120Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.2.0/openapi-generator-cli-7.2.0.jar'
+    },
+    {
+      version: '7.1.0',
+      versionTags: [ '7.1.0', 'stable' ],
+      releaseDate: new Date("2023-11-13T09:44:25.982Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.1.0/openapi-generator-cli-7.1.0.jar'
+    },
+    {
+      version: '7.0.1',
+      versionTags: [ '7.0.1', 'stable' ],
+      releaseDate: new Date("2023-09-18T09:09:18.699Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.0.1/openapi-generator-cli-7.0.1.jar'
+    },
+    {
+      version: '7.0.0',
+      versionTags: [ '7.0.0', 'stable' ],
+      releaseDate: new Date("2023-08-25T07:21:58.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.0.0/openapi-generator-cli-7.0.0.jar'
+    },
+    {
+      version: '7.0.0-beta',
+      versionTags: [ '7.0.0-beta', '7.0.0', 'beta', 'beta' ],
+      releaseDate: new Date("2023-07-06T08:20:49.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.0.0-beta/openapi-generator-cli-7.0.0-beta.jar'
+    },
+    {
+      version: '6.6.0',
+      versionTags: [ '6.6.0', 'stable' ],
+      releaseDate: new Date("2023-05-11T02:17:01.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.6.0/openapi-generator-cli-6.6.0.jar'
+    },
+    {
+      version: '6.5.0',
+      versionTags: [ '6.5.0', 'stable' ],
+      releaseDate: new Date("2023-04-01T07:18:53.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.5.0/openapi-generator-cli-6.5.0.jar'
+    },
+    {
+      version: '6.4.0',
+      versionTags: [ '6.4.0', 'stable' ],
+      releaseDate: new Date("2023-02-19T11:09:30.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.4.0/openapi-generator-cli-6.4.0.jar'
+    },
+    {
+      version: '6.3.0',
+      versionTags: [ '6.3.0', 'stable' ],
+      releaseDate: new Date("2023-02-01T13:08:43.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.3.0/openapi-generator-cli-6.3.0.jar'
+    },
+    {
+      version: '6.2.1',
+      versionTags: [ '6.2.1', 'stable' ],
+      releaseDate: new Date("2022-11-01T09:44:24.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.2.1/openapi-generator-cli-6.2.1.jar'
+    },
+    {
+      version: '6.2.0',
+      versionTags: [ '6.2.0', 'stable' ],
+      releaseDate: new Date("2022-09-24T14:10:07.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.2.0/openapi-generator-cli-6.2.0.jar'
+    },
+    {
+      version: '6.1.0',
+      versionTags: [ '6.1.0', 'stable' ],
+      releaseDate: new Date("2022-09-11T09:46:14.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.1.0/openapi-generator-cli-6.1.0.jar'
+    },
+    {
+      version: '6.0.1',
+      versionTags: [ '6.0.1', 'stable' ],
+      releaseDate: new Date("2022-07-03T16:24:08.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.0.1/openapi-generator-cli-6.0.1.jar'
+    },
+    {
+      version: '6.0.0',
+      versionTags: [ '6.0.0', 'stable' ],
+      releaseDate: new Date("2022-05-26T02:56:46.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.0.0/openapi-generator-cli-6.0.0.jar'
+    },
+    {
+      version: '6.0.0-beta',
+      versionTags: [ '6.0.0-beta', '6.0.0', 'beta', 'beta' ],
+      releaseDate: new Date("2022-04-04T03:01:01.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/6.0.0-beta/openapi-generator-cli-6.0.0-beta.jar'
+    },
+    {
+      version: '5.4.0',
+      versionTags: [ '5.4.0', 'stable' ],
+      releaseDate: new Date("2022-01-31T05:34:05.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.4.0/openapi-generator-cli-5.4.0.jar'
+    },
+    {
+      version: '5.3.1',
+      versionTags: [ '5.3.1', 'stable' ],
+      releaseDate: new Date("2021-12-21T10:49:56.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.3.1/openapi-generator-cli-5.3.1.jar'
+    },
+    {
+      version: '5.3.0',
+      versionTags: [ '5.3.0', 'stable' ],
+      releaseDate: new Date("2021-10-24T14:53:19.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.3.0/openapi-generator-cli-5.3.0.jar'
+    },
+    {
+      version: '5.2.1',
+      versionTags: [ '5.2.1', 'stable' ],
+      releaseDate: new Date("2021-08-16T12:55:33.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.2.1/openapi-generator-cli-5.2.1.jar'
+    },
+    {
+      version: '5.2.0',
+      versionTags: [ '5.2.0', 'stable' ],
+      releaseDate: new Date("2021-07-09T09:44:53.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.2.0/openapi-generator-cli-5.2.0.jar'
+    },
+    {
+      version: '5.1.1',
+      versionTags: [ '5.1.1', 'stable' ],
+      releaseDate: new Date("2021-05-07T02:35:53.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.1.1/openapi-generator-cli-5.1.1.jar'
+    },
+    {
+      version: '5.1.0',
+      versionTags: [ '5.1.0', 'stable' ],
+      releaseDate: new Date("2021-03-20T09:21:09.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.1.0/openapi-generator-cli-5.1.0.jar'
+    },
+    {
+      version: '5.0.1',
+      versionTags: [ '5.0.1', 'stable' ],
+      releaseDate: new Date("2021-02-06T09:16:59.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.0.1/openapi-generator-cli-5.0.1.jar'
+    },
+    {
+      version: '5.0.0',
+      versionTags: [ '5.0.0', 'stable' ],
+      releaseDate: new Date("2020-12-21T05:42:21.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.0.0/openapi-generator-cli-5.0.0.jar'
+    },
+    {
+      version: '5.0.0-beta3',
+      versionTags: [ '5.0.0-beta3', '5.0.0', 'beta3', 'beta' ],
+      releaseDate: new Date("2020-11-20T08:54:14.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.0.0-beta3/openapi-generator-cli-5.0.0-beta3.jar'
+    },
+    {
+      version: '5.0.0-beta2',
+      versionTags: [ '5.0.0-beta2', '5.0.0', 'beta2', 'beta' ],
+      releaseDate: new Date("2020-09-04T05:38:38.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.0.0-beta2/openapi-generator-cli-5.0.0-beta2.jar'
+    },
+    {
+      version: '5.0.0-beta',
+      versionTags: [ '5.0.0-beta', '5.0.0', 'beta', 'beta' ],
+      releaseDate: new Date("2020-06-29T15:49:53.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/5.0.0-beta/openapi-generator-cli-5.0.0-beta.jar'
+    },
+    {
+      version: '4.3.1',
+      versionTags: [ '4.3.1', 'stable' ],
+      releaseDate: new Date("2020-05-06T09:43:40.000Z"),
+      installed: true,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.3.1/openapi-generator-cli-4.3.1.jar'
+    },
+    {
+      version: '4.3.0',
+      versionTags: [ '4.3.0', 'stable' ],
+      releaseDate: new Date("2020-03-27T04:03:55.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.3.0/openapi-generator-cli-4.3.0.jar'
+    },
+    {
+      version: '4.2.3',
+      versionTags: [ '4.2.3', 'stable' ],
+      releaseDate: new Date("2020-01-31T08:56:15.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.2.3/openapi-generator-cli-4.2.3.jar'
+    },
+    {
+      version: '4.2.2',
+      versionTags: [ '4.2.2', 'stable' ],
+      releaseDate: new Date("2019-12-02T05:46:08.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.2.2/openapi-generator-cli-4.2.2.jar'
+    },
+    {
+      version: '4.2.1',
+      versionTags: [ '4.2.1', 'stable' ],
+      releaseDate: new Date("2019-11-15T08:50:59.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.2.1/openapi-generator-cli-4.2.1.jar'
+    },
+    {
+      version: '4.2.0',
+      versionTags: [ '4.2.0', 'stable' ],
+      releaseDate: new Date("2019-10-31T04:09:29.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.2.0/openapi-generator-cli-4.2.0.jar'
+    },
+    {
+      version: '4.1.3',
+      versionTags: [ '4.1.3', 'stable' ],
+      releaseDate: new Date("2019-10-04T06:18:41.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.1.3/openapi-generator-cli-4.1.3.jar'
+    },
+    {
+      version: '4.1.2',
+      versionTags: [ '4.1.2', 'stable' ],
+      releaseDate: new Date("2019-09-11T11:10:43.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.1.2/openapi-generator-cli-4.1.2.jar'
+    },
+    {
+      version: '4.1.1',
+      versionTags: [ '4.1.1', 'stable' ],
+      releaseDate: new Date("2019-08-26T08:32:17.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.1.1/openapi-generator-cli-4.1.1.jar'
+    },
+    {
+      version: '4.1.0',
+      versionTags: [ '4.1.0', 'stable' ],
+      releaseDate: new Date("2019-08-09T15:01:49.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.1.0/openapi-generator-cli-4.1.0.jar'
+    },
+    {
+      version: '4.0.3',
+      versionTags: [ '4.0.3', 'stable' ],
+      releaseDate: new Date("2019-07-09T13:19:51.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.0.3/openapi-generator-cli-4.0.3.jar'
+    },
+    {
+      version: '4.0.2',
+      versionTags: [ '4.0.2', 'stable' ],
+      releaseDate: new Date("2019-06-20T05:07:08.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.0.2/openapi-generator-cli-4.0.2.jar'
+    },
+    {
+      version: '4.0.1',
+      versionTags: [ '4.0.1', 'stable' ],
+      releaseDate: new Date("2019-05-31T16:12:03.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.0.1/openapi-generator-cli-4.0.1.jar'
+    },
+    {
+      version: '4.0.0',
+      versionTags: [ '4.0.0', 'stable' ],
+      releaseDate: new Date("2019-05-13T13:27:43.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.0.0/openapi-generator-cli-4.0.0.jar'
+    },
+    {
+      version: '4.0.0-beta3',
+      versionTags: [ '4.0.0-beta3', '4.0.0', 'beta3', 'beta' ],
+      releaseDate: new Date("2019-04-04T13:22:16.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.0.0-beta3/openapi-generator-cli-4.0.0-beta3.jar'
+    },
+    {
+      version: '4.0.0-beta2',
+      versionTags: [ '4.0.0-beta2', '4.0.0', 'beta2', 'beta' ],
+      releaseDate: new Date("2019-01-31T23:40:38.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.0.0-beta2/openapi-generator-cli-4.0.0-beta2.jar'
+    },
+    {
+      version: '4.0.0-beta',
+      versionTags: [ '4.0.0-beta', '4.0.0', 'beta', 'beta' ],
+      releaseDate: new Date("2018-12-31T09:43:08.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/4.0.0-beta/openapi-generator-cli-4.0.0-beta.jar'
+    },
+    {
+      version: '3.3.4',
+      versionTags: [ '3.3.4', 'stable' ],
+      releaseDate: new Date("2018-11-30T17:36:10.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/3.3.4/openapi-generator-cli-3.3.4.jar'
+    },
+    {
+      version: '3.3.3',
+      versionTags: [ '3.3.3', 'stable' ],
+      releaseDate: new Date("2018-11-15T03:52:20.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/3.3.3/openapi-generator-cli-3.3.3.jar'
+    },
+    {
+      version: '3.3.2',
+      versionTags: [ '3.3.2', 'stable' ],
+      releaseDate: new Date("2018-10-31T13:22:25.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/3.3.2/openapi-generator-cli-3.3.2.jar'
+    },
+    {
+      version: '3.3.1',
+      versionTags: [ '3.3.1', 'stable' ],
+      releaseDate: new Date("2018-10-15T15:55:02.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/3.3.1/openapi-generator-cli-3.3.1.jar'
+    },
+    {
+      version: '3.3.0',
+      versionTags: [ '3.3.0', 'stable' ],
+      releaseDate: new Date("2018-10-01T16:35:32.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/3.3.0/openapi-generator-cli-3.3.0.jar'
+    },
+    {
+      version: '3.2.3',
+      versionTags: [ '3.2.3', 'stable' ],
+      releaseDate: new Date("2018-08-30T11:39:38.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/3.2.3/openapi-generator-cli-3.2.3.jar'
+    },
+    {
+      version: '3.2.2',
+      versionTags: [ '3.2.2', 'stable' ],
+      releaseDate: new Date("2018-08-22T09:17:07.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/3.2.2/openapi-generator-cli-3.2.2.jar'
+    },
+    {
+      version: '3.2.1',
+      versionTags: [ '3.2.1', 'stable' ],
+      releaseDate: new Date("2018-08-14T10:20:10.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/3.2.1/openapi-generator-cli-3.2.1.jar'
+    },
+    {
+      version: '3.2.0',
+      versionTags: [ '3.2.0', 'stable' ],
+      releaseDate: new Date("2018-08-06T14:35:21.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/3.2.0/openapi-generator-cli-3.2.0.jar'
+    },
+    {
+      version: '3.1.2',
+      versionTags: [ '3.1.2', 'stable' ],
+      releaseDate: new Date("2018-07-25T16:40:54.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/3.1.2/openapi-generator-cli-3.1.2.jar'
+    },
+    {
+      version: '3.1.1',
+      versionTags: [ '3.1.1', 'stable' ],
+      releaseDate: new Date("2018-07-18T08:02:30.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/3.1.1/openapi-generator-cli-3.1.1.jar'
+    },
+    {
+      version: '3.1.0',
+      versionTags: [ '3.1.0', 'stable' ],
+      releaseDate: new Date("2018-07-06T16:06:08.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/3.1.0/openapi-generator-cli-3.1.0.jar'
+    },
+    {
+      version: '3.0.3',
+      versionTags: [ '3.0.3', 'stable' ],
+      releaseDate: new Date("2018-06-27T14:14:10.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/3.0.3/openapi-generator-cli-3.0.3.jar'
+    },
+    {
+      version: '3.0.2',
+      versionTags: [ '3.0.2', 'stable' ],
+      releaseDate: new Date("2018-06-18T06:09:22.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/3.0.2/openapi-generator-cli-3.0.2.jar'
+    },
+    {
+      version: '3.0.1',
+      versionTags: [ '3.0.1', 'stable' ],
+      releaseDate: new Date("2018-06-11T16:20:09.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/3.0.1/openapi-generator-cli-3.0.1.jar'
+    },
+    {
+      version: '3.0.0',
+      versionTags: [ '3.0.0', 'stable' ],
+      releaseDate: new Date("2018-06-01T10:33:24.000Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/3.0.0/openapi-generator-cli-3.0.0.jar'
+    }
+  ];
 }


### PR DESCRIPTION
add fallback to a list of default versions if maven search returns errors so that users can still use openapi-generator without issues using a fixed set of released versions (e.g. 7.7.0)

later we will return fixed set of released versions as the default and search maven as a fallback (or if OPENAPI_GENERATOR_CLI_SEARCH_URL is set to `https://search.maven.org`)

cc @kay-schecker 