### PR TITLE
Just use process.cwd()

### DIFF
--- a/apps/generator-cli/src/app/services/config.service.ts
+++ b/apps/generator-cli/src/app/services/config.service.ts
@@ -8,7 +8,7 @@ import { Command } from 'commander';
 @Injectable()
 export class ConfigService {
 
-  public readonly cwd = process.env.PWD || process.env.INIT_CWD || process.cwd()
+  public readonly cwd = process.cwd()
   public readonly configFile = this.configFileOrDefault();
 
   private configFileOrDefault() {


### PR DESCRIPTION
Just use `process.cwd()`... So the behavior is consistent and doesn't change across operating systems.

Fix #690 