### PR TITLE
chore: add nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+has nix && use flake

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ Thumbs.db
 /openapitools.json
 
 .nx/cache
+
+# Direnv
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1727863144,
+        "narHash": "sha256-E9uNBPoac2pZ62a3k482RnMpDM9aQAG5PnFKi36cTQE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1ef7ab47629547cfdaeddee7b8cde510bae78d10",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -14,10 +14,8 @@
           {
             buildInputs = with pkgs;[
               # These dependencies match the github workflows
-              # yarn 1.x
               yarn
-              # nodejs without npm
-              nodejs-slim_18
+              nodejs_18
             ];
           };
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  description = "OpenAPI generator CLI nix flake";
+
+  inputs.nixpkgs.url = "github:nixos/nixpkgs";  
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        devShells.default = pkgs.mkShell
+          {
+            buildInputs = with pkgs;[
+              # These dependencies match the github workflows
+              # yarn 1.x
+              yarn
+              # nodejs without npm
+              nodejs-slim_18
+            ];
+          };
+      }
+    );
+}
+


### PR DESCRIPTION
This adds a nix flake similar to the one we have in https://github.com/OpenAPITools/openapi-generator

It installs yarn 1.x and node 18 ~w/o npm~ and adds a direnv directive.

update: we need npm, it seems we use it here: https://github.com/OpenAPITools/openapi-generator-cli/blob/113ee846c64c6cbda3107a010e7f975371e79b30/package.json#L54 in addition to yarn

The current lock file sets this to:
```
node --version
v18.20.4
yarn --version
1.22.22
npm --version
10.7.0
```

same as in the current `master`: https://github.com/OpenAPITools/openapi-generator-cli/actions/runs/11091950012/job/30816360053

<img width="294" alt="Screenshot 2024-10-02 at 11 14 47 AM" src="https://github.com/user-attachments/assets/ccca0b1b-76a9-4f0c-a0fc-485385d35255">
