### PR TITLE
chore: fix husky

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 yarn commitlint --edit $1

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "dep-graph": "nx dep-graph",
     "help": "nx help",
     "semantic-release": "semantic-release",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "collective": {
     "type": "opencollective",


### PR DESCRIPTION
Currently, when using this repo and trying to commit, this shows up:

<img width="451" alt="Screenshot 2024-10-02 at 11 17 21 AM" src="https://github.com/user-attachments/assets/c8f0515f-dc45-4e20-82c5-644afbd2844c">

and

<img width="451" alt="Screenshot 2024-10-02 at 11 19 56 AM" src="https://github.com/user-attachments/assets/b0c3f533-fc8b-43a0-b0c4-bfab650cd629">


(seen when opening #826)

references https://github.com/typicode/husky/issues/1480 and https://github.com/typicode/husky/releases/tag/v9.0.1#How%20to%20Migrate

