### PR TITLE
docs: remove slack link

### DIFF
--- a/apps/generator-cli/src/README.md
+++ b/apps/generator-cli/src/README.md
@@ -1,7 +1,5 @@
 # @openapitools/openapi-generator-cli
 
-[![Join the Slack chat room](https://img.shields.io/badge/Slack-Join%20the%20chat%20room-orange)](https://join.slack.com/t/openapi-generator/shared_invite/enQtNzAyNDMyOTU0OTE1LTY5ZDBiNDI5NzI5ZjQ1Y2E5OWVjMjZkYzY1ZGM2MWQ4YWFjMzcyNDY5MGI4NjQxNDBiMTlmZTc5NjY2ZTQ5MGM)
-
 ![Build](https://github.com/OpenAPITools/openapi-generator-cli/workflows/Build/badge.svg)
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovateapp.com/)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)


### PR DESCRIPTION
Current link yields:

<img width="763" alt="Screenshot 2024-10-02 at 1 28 27 PM" src="https://github.com/user-attachments/assets/c7c86121-9641-4592-96bb-511280285111">
