### PR TITLE
📦️ update vulnerable axios package to ^1.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "@nestjs/core": "^11.0.16",
     "@nestjs/platform-express": "^11.0.16",
     "@nuxtjs/opencollective": "0.3.2",
-    "axios": "^1.8.4",
+    "axios": "^1.12.0",
     "chalk": "4.1.2",
     "commander": "8.3.0",
     "compare-versions": "4.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3888,7 +3888,16 @@ autoprefixer@^10.4.9:
     picocolors "^1.1.1"
     postcss-value-parser "^4.2.0"
 
-axios@^1.8.3, axios@^1.8.4:
+axios@^1.12.0:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.12.1.tgz#0747b39c5b615f81f93f2c138e6d82a71426937f"
+  integrity sha512-Kn4kbSXpkFHCGE6rBFNwIv0GQs4AvDT80jlveJDKFxjbTYMUeB4QtsdPCv6H8Cm19Je7IU6VFtRl2zWZI0rudQ==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.4"
+    proxy-from-env "^1.1.0"
+
+axios@^1.8.3:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.11.0.tgz#c2ec219e35e414c025b2095e8b8280278478fdb6"
   integrity sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==


### PR DESCRIPTION
This PR updates the Axios dependency 📦️ to fix (https://github.com/advisories/GHSA-4hjh-wcwx-xvwj) vulnerability.. The change was verified by running the initial CLI build/tests and confirming that client generation still works as expected.
🔍✅ The following test were performed to test the openapi-generator-cli 🚑️🔒️

Updated the Axios dependency
Ran the local build and CLI tests successfully.
Generated both TypeScript and Python clients from a custom test specification.
npm run cli -- generate -i samples/test.yaml -g typescript-fetch -o tmp-client
npm run cli -- generate -i samples/test.yaml -g python -o tmp-client
Verified that the generated clients were built correctly and run as expected without errors.
Environment

Node.js v22.14.0,
NPM 10.9.2
java version "24.0.2" 2025-07-15
Java(TM) SE Runtime Environment (build 24.0.2+12-54)
Java HotSpot(TM) 64-Bit Server VM (build 24.0.2+12-54, mixed mode, sharing)
TypeScript 5.9.2
Python 3.11