### PR TITLE
Allow direct CLI invocations to use similar code to GeneratorService.cmd()

### DIFF
--- a/apps/generator-cli/src/app/services/pass-through.service.ts
+++ b/apps/generator-cli/src/app/services/pass-through.service.ts
@@ -2,6 +2,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import chalk from 'chalk';
 import { exec, spawn } from 'child_process';
 import { Command } from 'commander';
+import * as os from 'os';
 import { COMMANDER_PROGRAM, LOGGER } from '../constants';
 import { GeneratorService } from './generator.service';
 import { VersionManagerService } from './version-manager.service';
@@ -130,8 +131,14 @@ export class PassThroughService {
 
   private cmd() {
     if (this.configService.useDocker) {
+      const userInfo = os.userInfo();
+      const userArg =
+        userInfo.uid !== -1 ? `--user ${userInfo.uid}:${userInfo.gid}` : '';
+
       return [
-        `docker run --rm -v "${this.configService.cwd}:/local"`,
+        `docker run --rm`,
+        userArg,
+        `-v "${this.configService.cwd}:/local"`,
         this.versionManager.getDockerImageName(),
       ].join(' ');
     }


### PR DESCRIPTION
This makes PassThroughService.cmd() pass a --user command similarly to GeneratorService.cmd()

https://github.com/OpenAPITools/openapi-generator-cli/blob/cd66bf17a758a5171b2a35bdf45805ca47b7d5cc/apps/generator-cli/src/app/services/generator.service.ts#L232

In my build environment, this fixes file ownership issues when using direct CLI invocations with Docker.

The index.ts written by the CLI generator is owned by root user, when using 

```
pnpm openapi-generator-cli generate -g typescript-fetch -o /local/output -i /local/input.json
```

The current workaround is to write it into the openapitools.json as a generator and do 

```
pnpm openapi-generator-cli generate --generator-key typescript-api
```

which takes the code path which passes in --user and therefore produces user owned output files.