### PR TITLE
feat(release): v7.19.0 release

### DIFF
--- a/apps/generator-cli/src/app/services/version-manager.service.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.ts
@@ -288,8 +288,15 @@ export class VersionManagerService {
 
   versions : Version[] = [
     {
+      version: '7.19.0',
+      versionTags: [ '7.19.0', 'stable', 'latest' ],
+      releaseDate: new Date("2026-01-20T06:24:58.285Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.19.0/openapi-generator-cli-7.19.0.jar'
+    },
+    {
       version: '7.18.0',
-      versionTags: [ '7.18.0', 'stable', 'latest' ],
+      versionTags: [ '7.18.0', 'stable' ],
       releaseDate: new Date("2025-12-22T06:24:58.285Z"),
       installed: false,
       downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.18.0/openapi-generator-cli-7.18.0.jar'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Promoted 7.19.0 as latest and stable in the generator CLI version manager. Added release date and Maven download link for 7.19.0, and removed "latest" from 7.18.0.

<sup>Written for commit 14ad549b52cb2835c3e00a4bb65b0163162b1069. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

