### PR TITLE
fix: resolve Node 24+ spawn deprecation warning (DEP0190)

### DIFF
--- a/apps/generator-cli/src/app/services/pass-through.service.spec.ts
+++ b/apps/generator-cli/src/app/services/pass-through.service.spec.ts
@@ -178,8 +178,7 @@ describe('PassThroughService', () => {
               await program.parseAsync([name, ...argv], { from: 'user' });
               expect(childProcess.spawn).toHaveBeenNthCalledWith(
                 1,
-                'docker run --rm -v "/foo/bar:/local" openapitools/openapi-generator-cli:v4.2.1',
-                [name, ...argv],
+                `docker run --rm -v "/foo/bar:/local" openapitools/openapi-generator-cli:v4.2.1 ${name} ${argv.join(' ')}`,
                 {
                   stdio: 'inherit',
                   shell: true,
@@ -192,8 +191,7 @@ describe('PassThroughService', () => {
             await program.parseAsync([name, ...argv], { from: 'user' });
             expect(childProcess.spawn).toHaveBeenNthCalledWith(
               1,
-              'java -jar "/some/path/to/4.2.1.jar"',
-              [name, ...argv],
+              `java -jar "/some/path/to/4.2.1.jar" ${name} ${argv.join(' ')}`,
               {
                 stdio: 'inherit',
                 shell: true,
@@ -206,8 +204,7 @@ describe('PassThroughService', () => {
             await program.parseAsync([name, ...argv], { from: 'user' });
             expect(childProcess.spawn).toHaveBeenNthCalledWith(
               1,
-              'java java-opt-1=1 -jar "/some/path/to/4.2.1.jar"',
-              [name, ...argv],
+              `java java-opt-1=1 -jar "/some/path/to/4.2.1.jar" ${name} ${argv.join(' ')}`,
               {
                 stdio: 'inherit',
                 shell: true,
@@ -227,8 +224,7 @@ describe('PassThroughService', () => {
               `java -cp "${[
                 '/some/path/to/4.2.1.jar',
                 '../some/custom.jar',
-              ].join(cpDelimiter)}" org.openapitools.codegen.OpenAPIGenerator`,
-              [name, ...argv],
+              ].join(cpDelimiter)}" org.openapitools.codegen.OpenAPIGenerator ${name} ${argv.join(' ')}`,
               {
                 stdio: 'inherit',
                 shell: true,
@@ -303,8 +299,7 @@ describe('PassThroughService', () => {
                   it('spawns the correct process', () => {
                     expect(childProcess.spawn).toHaveBeenNthCalledWith(
                       1,
-                      'java -jar "/some/path/to/4.2.1.jar"',
-                      cmd.split(' '),
+                      `java -jar "/some/path/to/4.2.1.jar" ${cmd}`,
                       { stdio: 'inherit', shell: true }
                     );
                   });

--- a/apps/generator-cli/src/app/services/pass-through.service.ts
+++ b/apps/generator-cli/src/app/services/pass-through.service.ts
@@ -85,8 +85,11 @@ export class PassThroughService {
 
   public passThrough = (cmd: Command) => {
     const args = [cmd.name(), ...cmd.args];
+    // Join command and args into a single string to avoid Node 24+ deprecation warning
+    // DEP0190: passing args to spawn with shell: true concatenates without escaping
+    const fullCommand = [this.cmd(), ...args].join(' ');
 
-    spawn(this.cmd(), args, {
+    spawn(fullCommand, {
       stdio: 'inherit',
       shell: true,
     }).on('exit', process.exit);

--- a/apps/generator-cli/src/app/services/version-manager.service.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.ts
@@ -134,7 +134,8 @@ export class VersionManagerService {
   async remove(versionName: string) {
     if (this.configService.useDocker) {
       await new Promise<void>((resolve) => {
-        spawn('docker', ['rmi', this.getDockerImageName(versionName)], {
+        // Use single command string to avoid Node 24+ deprecation warning (DEP0190)
+        spawn(`docker rmi ${this.getDockerImageName(versionName)}`, {
           stdio: 'inherit',
           shell: true,
         }).on('exit', () => resolve());
@@ -151,7 +152,8 @@ export class VersionManagerService {
 
     if (this.configService.useDocker) {
       await new Promise<void>((resolve) => {
-        spawn('docker', ['pull', this.getDockerImageName(versionName)], {
+        // Use single command string to avoid Node 24+ deprecation warning (DEP0190)
+        spawn(`docker pull ${this.getDockerImageName(versionName)}`, {
           stdio: 'inherit',
           shell: true,
         }).on('exit', () => resolve());


### PR DESCRIPTION
## Summary

This PR fixes the Node 24+ deprecation warning (DEP0190) that occurs when running the tool:

```
(node:34628) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
```

## Changes

When using `spawn()` with `shell: true`, Node 24 now warns if args are passed as a separate array because they get concatenated internally anyway. This PR joins the command and arguments into a single command string before passing to `spawn()`, which is the recommended pattern.

### Files modified:
- `pass-through.service.ts` - Join command and args before spawning
- `version-manager.service.ts` - Fix docker rmi and pull spawn calls
- `pass-through.service.spec.ts` - Update test expectations to match new signature

## Testing

Updated unit tests to reflect the new spawn signature. The behavior remains identical - only the way arguments are passed to spawn has changed.

Fixes #1102

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Node 24+ DEP0190 warning by switching spawn calls with shell: true to a single command string, removing the deprecation warning without changing behavior. Fixes #1102.

- **Bug Fixes**
  - PassThroughService: join command and args into one string before spawn.
  - VersionManagerService: use single command string for docker pull/rmi.
  - Tests: update expectations to match the new spawn signature.

<sup>Written for commit 0a1328a4eaf17150c2002c99b6dca0ffccc355f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

