### PR TITLE
feat(release): v7.20.0 release

### DIFF
--- a/apps/generator-cli/src/app/services/version-manager.service.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.ts
@@ -290,8 +290,15 @@ export class VersionManagerService {
 
   versions : Version[] = [
     {
+      version: '7.20.0',
+      versionTags: [ '7.20.0', 'stable', 'latest' ],
+      releaseDate: new Date("2026-02-16T06:24:58.285Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.20.0/openapi-generator-cli-7.20.0.jar'
+    },
+    {
       version: '7.19.0',
-      versionTags: [ '7.19.0', 'stable', 'latest' ],
+      versionTags: [ '7.19.0', 'stable' ],
       releaseDate: new Date("2026-01-20T06:24:58.285Z"),
       installed: false,
       downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.19.0/openapi-generator-cli-7.19.0.jar'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Publish 7.20.0 in the version manager and make it the new stable/latest so the CLI defaults to it. Added release date and Maven download link; 7.19.0 is now marked stable only.

<sup>Written for commit afe19ab4aaaee7df00ac13e740597733b32f5ffb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

