### PR TITLE
simple auth for maven

### DIFF
--- a/apps/generator-cli/src/README.md
+++ b/apps/generator-cli/src/README.md
@@ -179,7 +179,7 @@ is automatically used to generate your code. 🎉
 
 ### Using custom / private maven registry 
 
-If you're using a private maven registry you can configure the `downloadUrl` and `queryUrl` like this:
+If you're using a private maven registry you can configure the `downloadUrl` and `queryUrl` and optional `username` and `password` like this:
 
 ```json
 {
@@ -189,7 +189,9 @@ If you're using a private maven registry you can configure the `downloadUrl` and
     "version": "7.8.0",
     "repository": {
       "queryUrl": "https://private.maven.intern/solrsearch/select?q=g:${group.id}+AND+a:${artifact.id}&core=gav&start=0&rows=200",
-      "downloadUrl": "https://private.maven.intern/maven2/${groupId}/${artifactId}/${versionName}/${artifactId}-${versionName}.jar"
+      "downloadUrl": "https://private.maven.intern/maven2/${groupId}/${artifactId}/${versionName}/${artifactId}-${versionName}.jar",
+      "username": "${env.MAVEN_USERNAME}",
+      "password": "${env.MAVEN_PASSWORD}"
     }
   }
 }

--- a/apps/generator-cli/src/app/services/version-manager.service.spec.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.spec.ts
@@ -23,6 +23,8 @@ describe('VersionManagerService', () => {
 
   const getVersion = jest.fn().mockReturnValue('4.3.0');
   const getStorageDir = jest.fn().mockReturnValue(undefined);
+  const getUsername = jest.fn().mockReturnValue(undefined);
+  const getPassword = jest.fn().mockReturnValue(undefined);
   const setVersion = jest.fn();
 
   let testBed: TestingModule;
@@ -50,6 +52,14 @@ describe('VersionManagerService', () => {
                 // return 'https://search.maven.custom/solrsearch/select?q=g:${repository.groupId}+AND+a:${repository.artifactId}&core=gav&start=0&rows=250';
               }
 
+              if (k === 'generator-cli.repository.username') {
+                return getUsername();
+              }
+
+              if (k === 'generator-cli.repository.password') {
+                return getPassword();
+              }
+
               return getVersion(k);
             },
             set: setVersion,
@@ -66,6 +76,8 @@ describe('VersionManagerService', () => {
   beforeEach(async () => {
     [get].forEach((fn) => fn.mockClear());
     getStorageDir.mockReturnValue(undefined);
+    getUsername.mockReturnValue(undefined);
+    getPassword.mockReturnValue(undefined);
     await compile();
     fs.existsSync
       .mockReset()
@@ -143,6 +155,7 @@ describe('VersionManagerService', () => {
         expect(get).toHaveBeenNthCalledWith(
           1,
           'https://central.sonatype.com/solrsearch/select?q=g:org.openapitools+AND+a:openapi-generator-cli&core=gav&start=0&rows=200',
+          {},
         );
       });
 
@@ -185,6 +198,7 @@ describe('VersionManagerService', () => {
           expect(get).toHaveBeenNthCalledWith(
             1,
             'https://central.sonatype.com/solrsearch/select?q=g:org.openapitools+AND+a:openapi-generator-cli&core=gav&start=0&rows=200',
+            {},
           );
         });
 
@@ -220,6 +234,7 @@ describe('VersionManagerService', () => {
           expect(get).toHaveBeenNthCalledWith(
             1,
             'https://central.sonatype.com/solrsearch/select?q=g:org.openapitools+AND+a:openapi-generator-cli&core=gav&start=0&rows=200',
+            {},
           );
         });
 
@@ -372,7 +387,10 @@ describe('VersionManagerService', () => {
 
         it('logs the correct messages', () => {
           expect(logMessages).toEqual({
-            before: [chalk.yellow(`Download 4.2.0 ...`)],
+            before: [
+              chalk.yellow(`Download 4.2.0 ...`),
+              chalk.yellow(`Downloading from repo1.maven.org ...`),
+            ],
             after: [
               chalk.red(`Download failed, because of: "HTTP 404 Not Found"`),
             ],
@@ -424,7 +442,10 @@ describe('VersionManagerService', () => {
         describe('logging', () => {
           it('logs the correct messages', () => {
             expect(logMessages).toEqual({
-              before: [chalk.yellow(`Download 4.2.0 ...`)],
+              before: [
+                chalk.yellow(`Download 4.2.0 ...`),
+                chalk.yellow(`Downloading from repo1.maven.org ...`),
+              ],
               after: [chalk.green(`Downloaded 4.2.0`)],
             });
           });
@@ -443,7 +464,10 @@ describe('VersionManagerService', () => {
               await compile();
               await fixture.download('4.2.0');
               expect(logMessages).toEqual({
-                before: [chalk.yellow(`Download 4.2.0 ...`)],
+                before: [
+                  chalk.yellow(`Download 4.2.0 ...`),
+                  chalk.yellow(`Downloading from repo1.maven.org ...`),
+                ],
                 after: [
                   chalk.green(
                     `Downloaded 4.2.0 to custom storage location ${expected}`,
@@ -598,6 +622,86 @@ describe('VersionManagerService', () => {
           getStorageDir.mockReturnValue(cfgValue);
           await compile();
           expect(fixture.storage).toEqual(expected);
+        });
+      });
+    });
+
+    describe('repository authentication', () => {
+      const mavenDocs = {
+        data: {
+          response: {
+            docs: [
+              { v: '4.2.0', timestamp: 1599197918000 },
+              { v: '4.3.1', timestamp: 1588758220000 },
+            ],
+          },
+        },
+      };
+
+      describe('when username and password are configured', () => {
+        beforeEach(async () => {
+          getUsername.mockReturnValue('myuser');
+          getPassword.mockReturnValue('mypass');
+          await compile();
+          get.mockReturnValue(of(mavenDocs));
+        });
+
+        it('passes auth to the query request', async () => {
+          await fixture.getAll().toPromise();
+          expect(get).toHaveBeenCalledWith(
+            expect.any(String),
+            { auth: { username: 'myuser', password: 'mypass' } },
+          );
+        });
+
+        it('passes auth to the download request', async () => {
+          const data = { pipe: jest.fn() };
+          const file = {
+            on: jest.fn().mockImplementation((listener, res) => {
+              if (listener === 'finish') return res();
+            }),
+          };
+
+          fs.mkdtempSync.mockReturnValue('/tmp/generator-cli-abcDEF');
+          fs.createWriteStream.mockReturnValue(file);
+          get.mockReturnValue(of({ data }));
+
+          await fixture.download('4.2.0');
+          expect(get).toHaveBeenCalledWith(
+            expect.any(String),
+            { responseType: 'stream', auth: { username: 'myuser', password: 'mypass' } },
+          );
+        });
+      });
+
+      describe('when only username is configured', () => {
+        beforeEach(async () => {
+          getUsername.mockReturnValue('myuser');
+          getPassword.mockReturnValue(undefined);
+          await compile();
+          get.mockReturnValue(of(mavenDocs));
+        });
+
+        it('does not pass auth to the query request', async () => {
+          await fixture.getAll();
+          expect(get).toHaveBeenCalledWith(
+            expect.any(String),
+            {},
+          );
+        });
+      });
+
+      describe('when neither username nor password is configured', () => {
+        beforeEach(async () => {
+          get.mockReturnValue(of(mavenDocs));
+        });
+
+        it('does not pass auth to the query request', async () => {
+          await fixture.getAll();
+          expect(get).toHaveBeenCalledWith(
+            expect.any(String),
+            {},
+          );
         });
       });
     });

--- a/apps/generator-cli/src/app/services/version-manager.service.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.ts
@@ -68,7 +68,7 @@ export class VersionManagerService {
           .default
     );
 
-    return this.httpService.get(queryUrl).pipe(
+    return this.httpService.get(queryUrl, this.getAuthConfig()).pipe(
       map(({ data }) => data.response.docs),
       map((docs) =>
         docs.map((doc) => ({
@@ -168,7 +168,7 @@ export class VersionManagerService {
 
     try {
       await this.httpService
-        .get<Stream>(downloadLink, { responseType: 'stream' })
+        .get<Stream>(downloadLink, { responseType: 'stream', ...this.getAuthConfig() })
         .pipe(
           switchMap(
             (res) =>
@@ -243,8 +243,7 @@ export class VersionManagerService {
   private createDownloadLink(versionName: string) {
     return this.replacePlaceholders(
       this.configService.get<string>('generator-cli.repository.downloadUrl') ||
-        configSchema.properties['generator-cli'].properties.repository
-          .downloadUrl.default,
+        configSchema.properties['generator-cli'].properties.repository.downloadUrl.default,
       { versionName }
     );
   }
@@ -263,6 +262,15 @@ export class VersionManagerService {
     }
 
     return str;
+  }
+
+  private getAuthConfig() {
+    const username = this.configService.get<string>('generator-cli.repository.username');
+    const password = this.configService.get<string>('generator-cli.repository.password');
+    if (username && password) {
+      return { auth: { username, password } };
+    }
+    return {};
   }
 
   private printResponseError(error: AxiosError) {

--- a/apps/generator-cli/src/config.schema.json
+++ b/apps/generator-cli/src/config.schema.json
@@ -24,13 +24,24 @@
           "type": "string"
         },
         "repository": {
-          "queryUrl": {
-            "type": "string",
+          "type": "object",
+          "properties": {
+            "queryUrl": {
+              "type": "string",
             "default": "https://central.sonatype.com/solrsearch/select?q=g:${group.id}+AND+a:${artifact.id}&core=gav&start=0&rows=200"
-          },
-          "downloadUrl": {
-            "type": "string",
-            "default": "https://repo1.maven.org/maven2/${groupId}/${artifactId}/${versionName}/${artifactId}-${versionName}.jar"
+            },
+            "downloadUrl": {
+              "type": "string",
+              "default": "https://repo1.maven.org/maven2/${groupId}/${artifactId}/${versionName}/${artifactId}-${versionName}.jar"
+            },
+            "username": {
+              "type": "string",
+              "description": "Username for authenticating against the maven repository. Supports ${env.VAR_NAME} placeholders."
+            },
+            "password": {
+              "type": "string",
+              "description": "Password for authenticating against the maven repository. Supports ${env.VAR_NAME} placeholders."
+            }
           }
         },
         "useDocker": {

--- a/apps/generator-cli/src/config.schema.json
+++ b/apps/generator-cli/src/config.schema.json
@@ -24,8 +24,6 @@
           "type": "string"
         },
         "repository": {
-          "type": "object",
-          "properties": {
             "queryUrl": {
               "type": "string",
             "default": "https://central.sonatype.com/solrsearch/select?q=g:${group.id}+AND+a:${artifact.id}&core=gav&start=0&rows=200"
@@ -42,7 +40,6 @@
               "type": "string",
               "description": "Password for authenticating against the maven repository. Supports ${env.VAR_NAME} placeholders."
             }
-          }
         },
         "useDocker": {
           "type": "boolean",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add basic auth support for private Maven repositories in the `generator-cli`. When both username and password are set, version lookups and downloads use HTTP Basic Auth, with clearer download logging.

- **New Features**
  - Added `generator-cli.repository.username` and `generator-cli.repository.password` (supports `${env.VAR_NAME}`).
  - Sends HTTP `auth` only when both values are provided for query and download requests.
  - Logs the repository hostname before downloading.
  - Updated README and tests for authenticated and unauthenticated cases.

- **Refactors**
  - Simplified `config.schema.json` by inlining `repository` fields (removed `properties` wrapper).

<sup>Written for commit 4c95e65d3fd0dcb0a83953d2874c0299678e248d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

