### PR TITLE
feat(release): v7.21.0 release

### DIFF
--- a/apps/generator-cli/src/app/services/version-manager.service.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.ts
@@ -290,8 +290,15 @@ export class VersionManagerService {
 
   versions : Version[] = [
     {
+      version: '7.21.0',
+      versionTags: [ '7.21.0', 'stable', 'latest' ],
+      releaseDate: new Date("2026-03-24T06:24:58.285Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.21.0/openapi-generator-cli-7.21.0.jar'
+    },
+    {
       version: '7.20.0',
-      versionTags: [ '7.20.0', 'stable', 'latest' ],
+      versionTags: [ '7.20.0', 'stable' ],
       releaseDate: new Date("2026-02-16T06:24:58.285Z"),
       installed: false,
       downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.20.0/openapi-generator-cli-7.20.0.jar'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds v7.21.0 to the `generator-cli` version list and promotes it to `stable`/`latest`. Updates v7.20.0 tags by removing `latest` and sets v7.21.0 release date and Maven download link.

<sup>Written for commit b9ae6b9a0159e5aa3390c0ef2f882c8c4c897651. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

