### PR TITLE
feat(release): v7.22.0 release

### DIFF
--- a/apps/generator-cli/src/app/services/version-manager.service.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.ts
@@ -290,8 +290,15 @@ export class VersionManagerService {
 
   versions : Version[] = [
     {
+      version: '7.22.0',
+      versionTags: [ '7.22.0', 'stable', 'latest' ],
+      releaseDate: new Date("2026-04-28T06:24:58.285Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.22.0/openapi-generator-cli-7.22.0.jar'
+    },
+    {
       version: '7.21.0',
-      versionTags: [ '7.21.0', 'stable', 'latest' ],
+      versionTags: [ '7.21.0', 'stable' ],
       releaseDate: new Date("2026-03-24T06:24:58.285Z"),
       installed: false,
       downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.21.0/openapi-generator-cli-7.21.0.jar'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds v7.22.0 to the VersionManagerService with release date and Maven download link, tagged as `stable` and `latest`. Removes the `latest` tag from 7.21.0.

<sup>Written for commit 142076b3fae5ab8b470172df8a6962d4e6311b86. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator-cli/pull/1194?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

