### PR TITLE
chore(fix): fix proxy agent

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,8 @@ jobs:
           (npm run oa version-manager set 4.3.1 && npm run oa version | grep -q '4.3.1') || exit 1
           test -f ~/my/storage/4.3.1.jar || exit 1
           npm run oa:generate && mkdir ./foo && cd ./foo && npm run oa:generate
-
+          # with http proxy
+          HTTP_PROXY=http://35.209.198.222:80 npm run oa generate -- -g ruby -i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o $GITHUB_WORKSPACE/tmp/ruby-client
 #  release:
 #    if: github.event.pull_request.merged == 'true'
 #    name: Release (Dry)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,13 +92,13 @@ jobs:
           (npm run oa version-manager set 4.3.1 && npm run oa version | grep -q '4.3.1') || exit 1
           test -f ~/my/storage/4.3.1.jar || exit 1
           npm run oa:generate && mkdir ./foo && cd ./foo && npm run oa:generate
-      #- name: Test with HTTP proxy
-      #  run: |
-      #    cd ./examples
-      #    yarn global add json && export PATH="$(yarn global bin):$PATH"
-      #    yarn cache clean && yarn add $GITHUB_WORKSPACE/package.tgz
-      #    export HTTP_PROXY=http://proxy_ip:proxy_port
-      #    npm run oa generate -- -g ruby -i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o $GITHUB_WORKSPACE/tmp/ruby-client
+      - name: Test with HTTP proxy
+        run: |
+          cd ./examples
+          yarn global add json && export PATH="$(yarn global bin):$PATH"
+          yarn cache clean && yarn add $GITHUB_WORKSPACE/package.tgz
+          export HTTP_PROXY=http://127.0.0.1:1234
+          npm run oa generate -- -g ruby -i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o $GITHUB_WORKSPACE/tmp/ruby-client
 #  rel#ease:
 #    if: github.event.pull_request.merged == 'true'
 #    name: Release (Dry)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
           test -f ~/my/storage/4.3.1.jar || exit 1
           npm run oa:generate && mkdir ./foo && cd ./foo && npm run oa:generate
           # with http proxy
-          HTTP_PROXY=http://35.209.198.222:80 npm run oa generate -- -g ruby -i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o $GITHUB_WORKSPACE/tmp/ruby-client
+          HTTP_PROXY=http://35.209.198.1:7080 npm run oa generate -- -g ruby -i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o $GITHUB_WORKSPACE/tmp/ruby-client
 #  release:
 #    if: github.event.pull_request.merged == 'true'
 #    name: Release (Dry)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,13 +92,13 @@ jobs:
           (npm run oa version-manager set 4.3.1 && npm run oa version | grep -q '4.3.1') || exit 1
           test -f ~/my/storage/4.3.1.jar || exit 1
           npm run oa:generate && mkdir ./foo && cd ./foo && npm run oa:generate
-      - name: Test with HTTP proxy
-        run: |
-          cd ./examples
-          yarn global add json && export PATH="$(yarn global bin):$PATH"
-          yarn cache clean && yarn add $GITHUB_WORKSPACE/package.tgz
-          export HTTP_PROXY=http://127.0.0.1:1234
-          npm run oa generate -- -g ruby -i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o $GITHUB_WORKSPACE/tmp/ruby-client
+      #- name: Test with HTTP proxy
+      #  run: |
+      #    cd ./examples
+      #    yarn global add json && export PATH="$(yarn global bin):$PATH"
+      #    yarn cache clean && yarn add $GITHUB_WORKSPACE/package.tgz
+      #    export HTTP_PROXY=http://proxy_ip:proxy_port
+      #    npm run oa generate -- -g ruby -i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o $GITHUB_WORKSPACE/tmp/ruby-client
 #  rel#ease:
 #    if: github.event.pull_request.merged == 'true'
 #    name: Release (Dry)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,14 +92,14 @@ jobs:
           (npm run oa version-manager set 4.3.1 && npm run oa version | grep -q '4.3.1') || exit 1
           test -f ~/my/storage/4.3.1.jar || exit 1
           npm run oa:generate && mkdir ./foo && cd ./foo && npm run oa:generate
-      - name: Test with HTTP proxy
-        run: |
-          cd ./examples
-          yarn global add json && export PATH="$(yarn global bin):$PATH"
-          yarn cache clean && yarn add $GITHUB_WORKSPACE/package.tgz
-          export HTTP_PROXY=http://35.209.198.1:7080
-          npm run oa generate -- -g ruby -i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o $GITHUB_WORKSPACE/tmp/ruby-client
-#  release:
+      #- name: Test with HTTP proxy
+      #  run: |
+      #    cd ./examples
+      #    yarn global add json && export PATH="$(yarn global bin):$PATH"
+      #    yarn cache clean && yarn add $GITHUB_WORKSPACE/package.tgz
+      #    export HTTP_PROXY=http://proxy_ip:proxy_port
+      #    npm run oa generate -- -g ruby -i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o $GITHUB_WORKSPACE/tmp/ruby-client
+#  rel#ease:
 #    if: github.event.pull_request.merged == 'true'
 #    name: Release (Dry)
 #    # needs: e2e # DONT FORGET TO ENABLE ME !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,8 +92,9 @@ jobs:
           (npm run oa version-manager set 4.3.1 && npm run oa version | grep -q '4.3.1') || exit 1
           test -f ~/my/storage/4.3.1.jar || exit 1
           npm run oa:generate && mkdir ./foo && cd ./foo && npm run oa:generate
-          # with http proxy
-          HTTP_PROXY=http://35.209.198.1:7080 npm run oa generate -- -g ruby -i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o $GITHUB_WORKSPACE/tmp/ruby-client
+        - name: Test with HTTP proxy
+          export HTTP_PROXY=http://35.209.198.1:7080
+          npm run oa generate -- -g ruby -i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o $GITHUB_WORKSPACE/tmp/ruby-client
 #  release:
 #    if: github.event.pull_request.merged == 'true'
 #    name: Release (Dry)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,9 @@ jobs:
           npm run oa:generate && mkdir ./foo && cd ./foo && npm run oa:generate
       - name: Test with HTTP proxy
         run: |
+          cd ./examples
+          yarn global add json && export PATH="$(yarn global bin):$PATH"
+          yarn cache clean && yarn add $GITHUB_WORKSPACE/package.tgz
           export HTTP_PROXY=http://35.209.198.1:7080
           npm run oa generate -- -g ruby -i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o $GITHUB_WORKSPACE/tmp/ruby-client
 #  release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,8 @@ jobs:
           (npm run oa version-manager set 4.3.1 && npm run oa version | grep -q '4.3.1') || exit 1
           test -f ~/my/storage/4.3.1.jar || exit 1
           npm run oa:generate && mkdir ./foo && cd ./foo && npm run oa:generate
-        - name: Test with HTTP proxy
+      - name: Test with HTTP proxy
+        run: |
           export HTTP_PROXY=http://35.209.198.1:7080
           npm run oa generate -- -g ruby -i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o $GITHUB_WORKSPACE/tmp/ruby-client
 #  release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,14 +92,14 @@ jobs:
           (npm run oa version-manager set 4.3.1 && npm run oa version | grep -q '4.3.1') || exit 1
           test -f ~/my/storage/4.3.1.jar || exit 1
           npm run oa:generate && mkdir ./foo && cd ./foo && npm run oa:generate
-      - name: Test with HTTP proxy
-        run: |
-          cd ./examples
-          yarn global add json && export PATH="$(yarn global bin):$PATH"
-          yarn cache clean && yarn add $GITHUB_WORKSPACE/package.tgz
-          export HTTP_PROXY=http://127.0.0.1:1234
-          npm run oa generate -- -g ruby -i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o $GITHUB_WORKSPACE/tmp/ruby-client
-#  release:
+      #- name: Test with HTTP proxy
+      #  run: |
+      #    cd ./examples
+      #    yarn global add json && export PATH="$(yarn global bin):$PATH"
+      #    yarn cache clean && yarn add $GITHUB_WORKSPACE/package.tgz
+      #    export HTTP_PROXY=http://proxy_ip:proxy_port
+      #    npm run oa generate -- -g ruby -i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o $GITHUB_WORKSPACE/tmp/ruby-client
+#  rel#ease:
 #    if: github.event.pull_request.merged == 'true'
 #    name: Release (Dry)
 #    # needs: e2e # DONT FORGET TO ENABLE ME !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,14 +92,14 @@ jobs:
           (npm run oa version-manager set 4.3.1 && npm run oa version | grep -q '4.3.1') || exit 1
           test -f ~/my/storage/4.3.1.jar || exit 1
           npm run oa:generate && mkdir ./foo && cd ./foo && npm run oa:generate
-      #- name: Test with HTTP proxy
-      #  run: |
-      #    cd ./examples
-      #    yarn global add json && export PATH="$(yarn global bin):$PATH"
-      #    yarn cache clean && yarn add $GITHUB_WORKSPACE/package.tgz
-      #    export HTTP_PROXY=http://proxy_ip:proxy_port
-      #    npm run oa generate -- -g ruby -i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o $GITHUB_WORKSPACE/tmp/ruby-client
-#  rel#ease:
+      - name: Test with HTTP proxy
+        run: |
+          cd ./examples
+          yarn global add json && export PATH="$(yarn global bin):$PATH"
+          yarn cache clean && yarn add $GITHUB_WORKSPACE/package.tgz
+          export HTTP_PROXY=http://127.0.0.1:1234
+          npm run oa generate -- -g ruby -i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o $GITHUB_WORKSPACE/tmp/ruby-client
+#  release:
 #    if: github.event.pull_request.merged == 'true'
 #    name: Release (Dry)
 #    # needs: e2e # DONT FORGET TO ENABLE ME !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/apps/generator-cli/jest.config.ts
+++ b/apps/generator-cli/jest.config.ts
@@ -4,12 +4,9 @@ export default {
   preset: '../../jest.preset.js',
   testEnvironment: 'node',
   transform: {
-    '^.+\\.[cm]?[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
   },
-  transformIgnorePatterns: [
-    'node_modules/(?!(proxy-agent|agent-base|http-proxy-agent|https-proxy-agent|pac-proxy-agent|socks-proxy-agent|proxy-from-env)/)',
-  ],
-  moduleFileExtensions: ['ts', 'js', 'mjs', 'cjs', 'html'],
+  moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/apps/generator-cli',
   // snapshotFormat: { escapeString: true, printBasicPrototype: true },
 };

--- a/apps/generator-cli/jest.config.ts
+++ b/apps/generator-cli/jest.config.ts
@@ -4,9 +4,12 @@ export default {
   preset: '../../jest.preset.js',
   testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+    '^.+\\.[cm]?[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
   },
-  moduleFileExtensions: ['ts', 'js', 'html'],
+  transformIgnorePatterns: [
+    'node_modules/(?!(proxy-agent|agent-base|http-proxy-agent|https-proxy-agent|pac-proxy-agent|socks-proxy-agent|proxy-from-env)/)',
+  ],
+  moduleFileExtensions: ['ts', 'js', 'mjs', 'cjs', 'html'],
   coverageDirectory: '../../coverage/apps/generator-cli',
   // snapshotFormat: { escapeString: true, printBasicPrototype: true },
 };

--- a/apps/generator-cli/src/app/app.module.ts
+++ b/apps/generator-cli/src/app/app.module.ts
@@ -21,7 +21,6 @@ const proxyAgent = new ProxyAgent();
 if (hasHttpProxyEnvs) {
   httpModuleConfig.proxy = false;
   httpModuleConfig.httpAgent = proxyAgent;
-  console.log("Using HTTP proxy agent for HTTP requests");
 }
 
 if (hasHttpsProxyEnvs) {

--- a/apps/generator-cli/src/app/app.module.ts
+++ b/apps/generator-cli/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import { Inject, Module, OnApplicationBootstrap } from '@nestjs/common';
 import { HttpModule, HttpModuleOptions } from '@nestjs/axios';
 import { Command } from 'commander';
-import ProxyAgent from 'proxy-agent';
+import { ProxyAgent } from 'proxy-agent';
 
 import { COMMANDER_PROGRAM, LOGGER } from './constants';
 import { VersionManagerController } from './controllers/version-manager.controller';

--- a/apps/generator-cli/src/app/app.module.ts
+++ b/apps/generator-cli/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import { Inject, Module, OnApplicationBootstrap } from '@nestjs/common';
 import { HttpModule, HttpModuleOptions } from '@nestjs/axios';
 import { Command } from 'commander';
-import { ProxyAgent } from 'proxy-agent';
+import ProxyAgent from 'proxy-agent';
 
 import { COMMANDER_PROGRAM, LOGGER } from './constants';
 import { VersionManagerController } from './controllers/version-manager.controller';

--- a/apps/generator-cli/src/app/app.module.ts
+++ b/apps/generator-cli/src/app/app.module.ts
@@ -1,6 +1,7 @@
 import { Inject, Module, OnApplicationBootstrap } from '@nestjs/common';
 import { HttpModule, HttpModuleOptions } from '@nestjs/axios';
 import { Command } from 'commander';
+import { ProxyAgent } from 'proxy-agent';
 
 import { COMMANDER_PROGRAM, LOGGER } from './constants';
 import { VersionManagerController } from './controllers/version-manager.controller';
@@ -15,19 +16,16 @@ import {
 const hasHttpProxyEnvs = process.env.HTTP_PROXY || process.env.http_proxy;
 const hasHttpsProxyEnvs = process.env.HTTPS_PROXY || process.env.https_proxy;
 const httpModuleConfig: HttpModuleOptions = {};
+const proxyAgent = new ProxyAgent();
 
 if (hasHttpProxyEnvs) {
   httpModuleConfig.proxy = false;
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const ProxyAgent = require('proxy-agent').default ?? require('proxy-agent');
-  httpModuleConfig.httpAgent = new ProxyAgent();
+  httpModuleConfig.httpAgent = proxyAgent;
 }
 
 if (hasHttpsProxyEnvs) {
   httpModuleConfig.proxy = false;
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const ProxyAgent = require('proxy-agent').default ?? require('proxy-agent');
-  httpModuleConfig.httpsAgent = new ProxyAgent();
+  httpModuleConfig.httpsAgent = proxyAgent;
 }
 
 @Module({

--- a/apps/generator-cli/src/app/app.module.ts
+++ b/apps/generator-cli/src/app/app.module.ts
@@ -21,6 +21,7 @@ const proxyAgent = new ProxyAgent();
 if (hasHttpProxyEnvs) {
   httpModuleConfig.proxy = false;
   httpModuleConfig.httpAgent = proxyAgent;
+  console.log("Using HTTP proxy agent for HTTP requests");
 }
 
 if (hasHttpsProxyEnvs) {

--- a/apps/generator-cli/src/proxy-agent.d.ts
+++ b/apps/generator-cli/src/proxy-agent.d.ts
@@ -1,0 +1,5 @@
+declare module 'proxy-agent' {
+  const ProxyAgent: new (...args: any[]) => any;
+  export default ProxyAgent;
+  export { ProxyAgent };
+}

--- a/apps/generator-cli/src/proxy-agent.d.ts
+++ b/apps/generator-cli/src/proxy-agent.d.ts
@@ -1,0 +1,6 @@
+declare module 'proxy-agent' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ProxyAgent: new (...args: any[]) => any;
+  export default ProxyAgent;
+  export { ProxyAgent };
+}

--- a/apps/generator-cli/src/proxy-agent.d.ts
+++ b/apps/generator-cli/src/proxy-agent.d.ts
@@ -1,4 +1,5 @@
 declare module 'proxy-agent' {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const ProxyAgent: new (...args: any[]) => any;
   export default ProxyAgent;
   export { ProxyAgent };

--- a/apps/generator-cli/src/proxy-agent.d.ts
+++ b/apps/generator-cli/src/proxy-agent.d.ts
@@ -1,6 +1,0 @@
-declare module 'proxy-agent' {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const ProxyAgent: new (...args: any[]) => any;
-  export default ProxyAgent;
-  export { ProxyAgent };
-}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes proxy handling in the generator CLI so HTTP(S) requests honor `HTTP_PROXY`/`HTTPS_PROXY`. Adds a `proxy-agent` type shim and Jest config updates; temporarily disables the HTTP proxy check in CI.

- **Bug Fixes**
  - Import named `ProxyAgent` from `proxy-agent`; reuse a single instance for `httpAgent`/`httpsAgent`.
  - Set `proxy = false` in `@nestjs/axios` when proxy envs are present.
  - Add `apps/generator-cli/src/proxy-agent.d.ts` to support both default and named imports.
  - Jest: broaden transform to `^.+\\.[cm]?[tj]s$`, include `mjs`/`cjs`, and allowlist `proxy-agent` deps in `transformIgnorePatterns`.

- **CI**
  - Comment out the "Test with HTTP proxy" step in `.github/workflows/build.yml`.

<sup>Written for commit 28f5509fc03403fecf079c59ab6634ba4778a13d. Summary will update on new commits. <a href="https://cubic.dev/pr/OpenAPITools/openapi-generator-cli/pull/1206?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

