### PR TITLE
feat(release): v7.23.0 release

### DIFF
--- a/apps/generator-cli/src/app/services/version-manager.service.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.ts
@@ -290,8 +290,15 @@ export class VersionManagerService {
 
   versions : Version[] = [
     {
+      version: '7.23.0',
+      versionTags: [ '7.23.0', 'stable', 'latest' ],
+      releaseDate: new Date("2026-06-08T06:24:58.285Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.23.0/openapi-generator-cli-7.23.0.jar'
+    },
+    {
       version: '7.22.0',
-      versionTags: [ '7.22.0', 'stable', 'latest' ],
+      versionTags: [ '7.22.0', 'stable' ],
       releaseDate: new Date("2026-04-28T06:24:58.285Z"),
       installed: false,
       downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.22.0/openapi-generator-cli-7.22.0.jar'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds 7.23.0 to the `VersionManagerService` list and marks it as `latest`/`stable`. Updates 7.22.0 tags to remove `latest`, and sets the release date and download link for 7.23.0.

<sup>Written for commit d593c1c896e6fb5d64c1480a8fe91e7b06950d9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator-cli/pull/1214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

