### PR TITLE
feat(release): trigger a release after upgrading to node 22.x

### DIFF
--- a/apps/generator-cli/src/README.md
+++ b/apps/generator-cli/src/README.md
@@ -308,3 +308,4 @@ yarn add @openapitools/openapi-generator-cli@1.0.18-4.3.1
 Please leave a star.
 
 
+


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Trigger a release after upgrading to Node 22.x. No code changes; only a README change to kick off the release pipeline.

<sup>Written for commit a3d5c06a2521f4e15c3199932a4e1cbb2da5933f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator-cli/pull/1217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

