### PR TITLE
chore(deps): update concurrently to newer version

### DIFF
--- a/apps/generator-cli/jest.config.ts
+++ b/apps/generator-cli/jest.config.ts
@@ -7,7 +7,7 @@ export default {
     '^.+\\.[cm]?[tj]s$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
   },
   transformIgnorePatterns: [
-    'node_modules/(?!(proxy-agent|agent-base|http-proxy-agent|https-proxy-agent|pac-proxy-agent|socks-proxy-agent|proxy-from-env)/)',
+    'node_modules/(?!(proxy-agent|agent-base|http-proxy-agent|https-proxy-agent|pac-proxy-agent|socks-proxy-agent|proxy-from-env|concurrently|chalk|supports-color|yargs|shell-quote|tree-kill|rxjs)/)',
   ],
   moduleFileExtensions: ['ts', 'js', 'mjs', 'cjs', 'html'],
   coverageDirectory: '../../coverage/apps/generator-cli',

--- a/apps/generator-cli/src/app/services/concurrently.adapter.ts
+++ b/apps/generator-cli/src/app/services/concurrently.adapter.ts
@@ -1,0 +1,10 @@
+import concurrently, {
+  type ConcurrentlyCommandInput,
+  type ConcurrentlyOptions,
+  type ConcurrentlyResult,
+} from 'concurrently';
+
+export const runConcurrently = (
+  commands: ConcurrentlyCommandInput[],
+  options?: Partial<ConcurrentlyOptions>
+): ConcurrentlyResult => concurrently(commands, options);

--- a/apps/generator-cli/src/app/services/generator.service.spec.ts
+++ b/apps/generator-cli/src/app/services/generator.service.spec.ts
@@ -3,19 +3,16 @@ import { GeneratorService } from './generator.service';
 import { LOGGER } from '../constants';
 import { VersionManagerService } from './version-manager.service';
 import { ConfigService } from './config.service';
+import { runConcurrently } from './concurrently.adapter';
 
 jest.mock('fs-extra');
 jest.mock('glob');
-jest.mock('concurrently');
+jest.mock('./concurrently.adapter');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const fs = jest.mocked(require('fs-extra'));
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const glob = jest.mocked(require('glob'));
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const concurrentlyModule = jest.mocked(require('concurrently'));
-const concurrently = (
-  concurrentlyModule.default ?? concurrentlyModule
-) as jest.Mock;
+const concurrently = jest.mocked(runConcurrently) as jest.Mock;
 
 describe('GeneratorService', () => {
   let fixture: GeneratorService;
@@ -115,7 +112,7 @@ describe('GeneratorService', () => {
       };
 
       let executedCommands = [];
-      let concurrentlyCfg = [];
+      let concurrentlyCfg = {};
 
       beforeEach(() => {
         executedCommands = [];

--- a/apps/generator-cli/src/app/services/generator.service.spec.ts
+++ b/apps/generator-cli/src/app/services/generator.service.spec.ts
@@ -12,7 +12,10 @@ const fs = jest.mocked(require('fs-extra'));
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const glob = jest.mocked(require('glob'));
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const concurrently = jest.mocked(require('concurrently'));
+const concurrentlyModule = jest.mocked(require('concurrently'));
+const concurrently = (
+  concurrentlyModule.default ?? concurrentlyModule
+) as jest.Mock;
 
 describe('GeneratorService', () => {
   let fixture: GeneratorService;

--- a/apps/generator-cli/src/app/services/generator.service.ts
+++ b/apps/generator-cli/src/app/services/generator.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 
-import concurrently, { type CloseEvent } from 'concurrently';
+import { type CloseEvent } from 'concurrently';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as glob from 'glob';
@@ -8,6 +8,7 @@ import chalk from 'chalk';
 import * as os from 'os';
 import { VersionManagerService } from './version-manager.service';
 import { ConfigService } from './config.service';
+import { runConcurrently } from './concurrently.adapter';
 import { LOGGER } from '../constants';
 
 interface GeneratorConfig {
@@ -94,7 +95,7 @@ export class GeneratorService {
       (await (async () => {
         try {
           this.printResult(
-            await concurrently(commands, { maxProcesses: 10 }).result,
+            await runConcurrently(commands, { maxProcesses: 10 }).result,
           );
           return true;
         } catch (e) {

--- a/nx.json
+++ b/nx.json
@@ -39,5 +39,6 @@
     }
   },
   "useInferencePlugins": false,
-  "defaultBase": "master"
+  "defaultBase": "master",
+  "analytics": false
 }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "chalk": "4.1.2",
     "commander": "8.3.0",
     "compare-versions": "6.1.1",
-    "concurrently": "^9.0.0",
+    "concurrently": "^10.0.0",
     "console.table": "0.10.0",
     "fs-extra": "11.3.5",
     "glob": "13.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4491,6 +4491,11 @@ chalk@4.1.2, chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@5.6.2, chalk@^5.4.1, chalk@^5.6.2:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.6.2.tgz#b1238b6e23ea337af71c7f8a295db5af0c158aea"
+  integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
+
 chalk@^2.3.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -4499,11 +4504,6 @@ chalk@^2.3.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^5.4.1, chalk@^5.6.2:
-  version "5.6.2"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.6.2.tgz#b1238b6e23ea337af71c7f8a295db5af0c158aea"
-  integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
 
 char-regex@^1.0.2:
   version "1.0.2"
@@ -4796,17 +4796,17 @@ concat-stream@^2.0.0:
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
 
-concurrently@^9.0.0:
-  version "9.2.1"
-  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-9.2.1.tgz#248ea21b95754947be2dad9c3e4b60f18ca4e44f"
-  integrity sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==
+concurrently@^10.0.0:
+  version "10.0.3"
+  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-10.0.3.tgz#0ae4bf732e958b1a607b47896dcaa836b72514e8"
+  integrity sha512-hc3LH4UaKWd/bbyDK/IGVa4RB6PtQ3CUYwtrkzqHn+wIG3Hr5fhpRlk0L/gCa8ZE1L/Ufj50Zho69cI5w8SQBA==
   dependencies:
-    chalk "4.1.2"
+    chalk "5.6.2"
     rxjs "7.8.2"
-    shell-quote "1.8.3"
-    supports-color "8.1.1"
+    shell-quote "1.8.4"
+    supports-color "10.2.2"
     tree-kill "1.2.2"
-    yargs "17.7.2"
+    yargs "18.0.0"
 
 config-chain@^1.1.11:
   version "1.1.13"
@@ -9438,9 +9438,9 @@ postcss-reduce-transforms@^7.0.3:
     postcss-value-parser "^4.2.0"
 
 postcss-selector-parser@^7.0.0, postcss-selector-parser@^7.1.1:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-7.1.2.tgz#e2dc51fc26c007a29bc3195ee9e68ca6df52e32e"
-  integrity sha512-Wjvt4scRFouioIInHf51IFNP4ltJ2EngJM+cZPGiqbKetBfmP3vpdPV8ID2S6JS6/jdo74N8+aEYH9lQr2C6sA==
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-7.1.3.tgz#6a65f1707b330c70430267d5a0eebc16064f33c5"
+  integrity sha512-ajnd7iZnqjJDkyHNfznl/ZVO0lWqvBmQXfKKENx9/p/bEiF/L3eHwdydNUg9RXZx6xfZWOCmXmBa5oeB+YrAPQ==
   dependencies:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
@@ -10275,12 +10275,7 @@ shell-exec@1.0.2:
   resolved "https://registry.yarnpkg.com/shell-exec/-/shell-exec-1.0.2.tgz#2e9361b0fde1d73f476c4b6671fa17785f696756"
   integrity sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg==
 
-shell-quote@1.8.3:
-  version "1.8.3"
-  resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.3.tgz#55e40ef33cf5c689902353a3d8cd1a6725f08b4b"
-  integrity sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==
-
-shell-quote@^1.8.4:
+shell-quote@1.8.4, shell-quote@^1.8.4:
   version "1.8.4"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.8.4.tgz#2edd9a4dcefc96649e2e2cb12f637b1f1d92a190"
   integrity sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==
@@ -10721,14 +10716,7 @@ super-regex@^1.0.0:
     make-asynchronous "^1.0.1"
     time-span "^5.1.0"
 
-supports-color@8.1.1, supports-color@^8.0.0, supports-color@^8.1.1:
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
-  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
-  dependencies:
-    has-flag "^4.0.0"
-
-supports-color@^10.2.2:
+supports-color@10.2.2, supports-color@^10.2.2:
   version "10.2.2"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-10.2.2.tgz#466c2978cc5cd0052d542a0b576461c2b802ebb4"
   integrity sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==
@@ -10744,6 +10732,13 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
+supports-color@^8.0.0, supports-color@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
+  integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
   dependencies:
     has-flag "^4.0.0"
 
@@ -11761,18 +11756,17 @@ yargs-parser@^22.0.0:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-22.0.0.tgz#87b82094051b0567717346ecd00fd14804b357c8"
   integrity sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==
 
-yargs@17.7.2, yargs@^17.6.2, yargs@^17.7.2:
-  version "17.7.2"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
-  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+yargs@18.0.0, yargs@^18.0.0:
+  version "18.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-18.0.0.tgz#6c84259806273a746b09f579087b68a3c2d25bd1"
+  integrity sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==
   dependencies:
-    cliui "^8.0.1"
+    cliui "^9.0.1"
     escalade "^3.1.1"
     get-caller-file "^2.0.5"
-    require-directory "^2.1.1"
-    string-width "^4.2.3"
+    string-width "^7.2.0"
     y18n "^5.0.5"
-    yargs-parser "^21.1.1"
+    yargs-parser "^22.0.0"
 
 yargs@^16.0.0:
   version "16.2.0"
@@ -11787,17 +11781,18 @@ yargs@^16.0.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^18.0.0:
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-18.0.0.tgz#6c84259806273a746b09f579087b68a3c2d25bd1"
-  integrity sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==
+yargs@^17.6.2, yargs@^17.7.2:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
   dependencies:
-    cliui "^9.0.1"
+    cliui "^8.0.1"
     escalade "^3.1.1"
     get-caller-file "^2.0.5"
-    string-width "^7.2.0"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
     y18n "^5.0.5"
-    yargs-parser "^22.0.0"
+    yargs-parser "^21.1.1"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Upgraded `concurrently` to v10 and added a `runConcurrently` adapter for its ESM export, updating tests and Jest config so generator CLI runs and tests pass. Disabled Nx analytics.

- **Refactors**
  - Switched service/tests to `./concurrently.adapter` and extended Jest `transformIgnorePatterns` for `concurrently`, `chalk`, `supports-color`, `yargs`, `shell-quote`, `tree-kill`, `rxjs`.

- **Dependencies**
  - Bumped `concurrently` to `^10.0.0`; lockfile updates include `chalk@5`, `supports-color@10`, `yargs@18`, `shell-quote@1.8.4`.

<sup>Written for commit 134f401be14bfbbc5a2383437c6d9771a6d89733. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator-cli/pull/1222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

