### PR TITLE
test: fix paths for Windows

### DIFF
--- a/apps/generator-cli/src/app/services/generator.service.spec.ts
+++ b/apps/generator-cli/src/app/services/generator.service.spec.ts
@@ -1,3 +1,4 @@
+import { delimiter, resolve } from 'path';
 import { Test } from '@nestjs/testing';
 import { GeneratorService } from './generator.service';
 import { LOGGER } from '../constants';
@@ -134,18 +135,18 @@ describe('GeneratorService', () => {
       const cmd = (name, appendix: string[]) => ({
         name,
         command: `java -jar "/path/to/4.2.1.jar" generate ${appendix.join(
-          ' '
+          ' ',
         )}`,
       });
 
       const cmdWithCustomJar = (
         name: string,
         customJar: string,
-        appendix: string[]
+        appendix: string[],
       ) => ({
         name,
-        command: `java -cp "/path/to/4.2.1.jar:${customJar}" org.openapitools.codegen.OpenAPIGenerator generate ${appendix.join(
-          ' '
+        command: `java -cp "/path/to/4.2.1.jar${delimiter}${customJar}" org.openapitools.codegen.OpenAPIGenerator generate ${appendix.join(
+          ' ',
         )}`,
       });
 
@@ -154,25 +155,25 @@ describe('GeneratorService', () => {
           'foo.json',
           [
             cmd('[angular] abc/app/pet.yaml', [
-              `--input-spec="${cwd}/abc/app/pet.yaml"`,
+              `--input-spec="${resolve(cwd, 'abc/app/pet.yaml')}"`,
               `--output="${cwd}/generated-sources/openapi/typescript-angular/pet"`,
               `--generator-name="typescript-angular"`,
               `--additional-properties="fileNaming=kebab-case,apiModulePrefix=Pet,npmName=petRestClient,supportsES6=true,withInterfaces=true"`,
             ]),
             cmd('[angular] abc/app/car.yaml', [
-              `--input-spec="${cwd}/abc/app/car.yaml"`,
+              `--input-spec="${resolve(cwd, 'abc/app/car.yaml')}"`,
               `--output="${cwd}/generated-sources/openapi/typescript-angular/car"`,
               `--generator-name="typescript-angular"`,
               `--additional-properties="fileNaming=kebab-case,apiModulePrefix=Car,npmName=carRestClient,supportsES6=true,withInterfaces=true"`,
             ]),
             cmd('[baz] def/app/pet.yaml', [
-              `--input-spec="${cwd}/def/app/pet.yaml"`,
+              `--input-spec="${resolve(cwd, 'def/app/pet.yaml')}"`,
               `--name="pet"`,
               `--name-uc-first="Pet"`,
               `--cwd="${cwd}"`,
               `--base="pet.yaml"`,
-              `--dir="${cwd}/def/app"`,
-              `--path="${cwd}/def/app/pet.yaml"`,
+              `--dir="${resolve(cwd, 'def/app')}"`,
+              `--path="${resolve(cwd, 'def/app/pet.yaml')}"`,
               `--rel-dir="def/app"`,
               `--rel-path="def/app/pet.yaml"`,
               `--ext="yaml"`,
@@ -180,13 +181,13 @@ describe('GeneratorService', () => {
               '--some-int=1',
             ]),
             cmd('[baz] def/app/car.json', [
-              `--input-spec="${cwd}/def/app/car.json"`,
+              `--input-spec="${resolve(cwd, 'def/app/car.json')}"`,
               `--name="car"`,
               `--name-uc-first="Car"`,
               `--cwd="${cwd}"`,
               `--base="car.json"`,
-              `--dir="${cwd}/def/app"`,
-              `--path="${cwd}/def/app/car.json"`,
+              `--dir="${resolve(cwd, 'def/app')}"`,
+              `--path="${resolve(cwd, 'def/app/car.json')}"`,
               `--rel-dir="def/app"`,
               `--rel-path="def/app/car.json"`,
               `--ext="json"`,
@@ -199,12 +200,12 @@ describe('GeneratorService', () => {
           'bar.json',
           [
             cmd('[bar] api/cat.yaml', [
-              `--input-spec="${cwd}/api/cat.yaml"`,
+              `--input-spec="${resolve(cwd, 'api/cat.yaml')}"`,
               `--output="bar/cat"`,
               '--some-bool',
             ]),
             cmd('[bar] api/bird.json', [
-              `--input-spec="${cwd}/api/bird.json"`,
+              `--input-spec="${resolve(cwd, 'api/bird.json')}"`,
               `--output="bar/bird"`,
               '--some-bool',
             ]),
@@ -214,12 +215,12 @@ describe('GeneratorService', () => {
           'bar.json',
           [
             cmdWithCustomJar('[bar] api/cat.yaml', '../some/custom.jar', [
-              `--input-spec="${cwd}/api/cat.yaml"`,
+              `--input-spec="${resolve(cwd, 'api/cat.yaml')}"`,
               `--output="bar/cat"`,
               '--some-bool',
             ]),
             cmdWithCustomJar('[bar] api/bird.json', '../some/custom.jar', [
-              `--input-spec="${cwd}/api/bird.json"`,
+              `--input-spec="${resolve(cwd, 'api/bird.json')}"`,
               `--output="bar/bird"`,
               '--some-bool',
             ]),
@@ -251,7 +252,7 @@ describe('GeneratorService', () => {
 
         beforeEach(async () => {
           configGet.mockImplementation(
-            (path, defaultValue) => config[filePath] || defaultValue
+            (path, defaultValue) => config[filePath] || defaultValue,
           );
           returnValue = await fixture.generate(customGenerator);
         });
@@ -260,7 +261,7 @@ describe('GeneratorService', () => {
           expect(configGet).toHaveBeenNthCalledWith(
             1,
             'generator-cli.generators',
-            {}
+            {},
           );
         });
 
@@ -296,11 +297,11 @@ describe('GeneratorService', () => {
           expect(executedCommands).toEqual([
             {
               name: '[bar] api/cat.yaml',
-              command: `java -jar "../some/custom.jar" generate --input-spec="${cwd}/api/cat.yaml" --output="bar/cat" --some-bool`,
+              command: `java -jar "../some/custom.jar" generate --input-spec="${resolve(cwd, 'api/cat.yaml')}" --output="bar/cat" --some-bool`,
             },
             {
               name: '[bar] api/bird.json',
-              command: `java -jar "../some/custom.jar" generate --input-spec="${cwd}/api/bird.json" --output="bar/bird" --some-bool`,
+              command: `java -jar "../some/custom.jar" generate --input-spec="${resolve(cwd, 'api/bird.json')}" --output="bar/bird" --some-bool`,
             },
           ]);
         });

--- a/apps/generator-cli/src/app/services/version-manager.service.spec.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.spec.ts
@@ -5,10 +5,9 @@ import { of } from 'rxjs';
 import { LOGGER } from '../constants';
 import chalk from 'chalk';
 import { ConfigService } from './config.service';
-import { resolve } from 'path';
+import { join, normalize, resolve } from 'path';
 import * as os from 'os';
 import { TestingModule } from '@nestjs/testing/testing-module';
-import * as path from 'path';
 
 jest.mock('fs-extra');
 
@@ -328,7 +327,7 @@ describe('VersionManagerService', () => {
       it('removes the correct file', () => {
         expect(fs.removeSync).toHaveBeenNthCalledWith(
           1,
-          `${fixture.storage}/4.3.1.jar`,
+          resolve(fixture.storage, '4.3.1.jar'),
         );
       });
 
@@ -446,7 +445,7 @@ describe('VersionManagerService', () => {
                 before: [chalk.yellow(`Download 4.2.0 ...`)],
                 after: [
                   chalk.green(
-                    `Downloaded 4.2.0 to custom storage location ${expected}`,
+                    `Downloaded 4.2.0 to custom storage location ${resolve(expected)}`,
                   ),
                 ],
               });
@@ -473,22 +472,22 @@ describe('VersionManagerService', () => {
           it('creates a temporary directory', () => {
             expect(fs.mkdtempSync).toHaveBeenNthCalledWith(
               1,
-              path.join(os.tmpdir(), 'generator-cli-'),
+              join(os.tmpdir(), 'generator-cli-'),
             );
           });
 
           it('creates the correct write stream', () => {
             expect(fs.createWriteStream).toHaveBeenNthCalledWith(
               1,
-              '/tmp/generator-cli-abcDEF/4.2.0',
+              normalize('/tmp/generator-cli-abcDEF/4.2.0'),
             );
           });
 
           it('moves the file to the target location', () => {
             expect(fs.moveSync).toHaveBeenNthCalledWith(
               1,
-              '/tmp/generator-cli-abcDEF/4.2.0',
-              `${fixture.storage}/4.2.0.jar`,
+              normalize('/tmp/generator-cli-abcDEF/4.2.0'),
+              resolve(fixture.storage, '4.2.0.jar'),
               { overwrite: true },
             );
           });
@@ -563,7 +562,7 @@ describe('VersionManagerService', () => {
         fixture.isDownloaded('4.3.1');
         expect(fs.existsSync).toHaveBeenNthCalledWith(
           1,
-          fixture.storage + '/4.3.1.jar',
+          resolve(fixture.storage, '4.3.1.jar'),
         );
       });
     });
@@ -571,12 +570,14 @@ describe('VersionManagerService', () => {
     describe('filePath()', () => {
       it('returns the path to the given version name', () => {
         expect(fixture.filePath('1.2.3')).toEqual(
-          `${fixture.storage}/1.2.3.jar`,
+          resolve(fixture.storage, '1.2.3.jar'),
         );
       });
 
       it('returns the path to the selected version name as default', () => {
-        expect(fixture.filePath()).toEqual(`${fixture.storage}/4.3.0.jar`);
+        expect(fixture.filePath()).toEqual(
+          resolve(fixture.storage, '4.3.0.jar'),
+        );
       });
     });
 
@@ -597,7 +598,7 @@ describe('VersionManagerService', () => {
         ])('returns %s for %s', async (expected, cfgValue) => {
           getStorageDir.mockReturnValue(cfgValue);
           await compile();
-          expect(fixture.storage).toEqual(expected);
+          expect(fixture.storage).toEqual(resolve(expected));
         });
       });
     });


### PR DESCRIPTION
Tested on Windows 10

Before:
```bash
Test Suites: 2 failed, 4 passed, 6 total
Tests:       17 failed, 206 passed, 223 total
Snapshots:   0 total
Time:        3.331 s, estimated 15 s
Ran all test suites.
```

After:
```bash
$ yarn test
yarn run v1.22.22
$ nx test generator-cli

> nx run generator-cli:test  [existing outputs match the cache, left as is]

 PASS   generator-cli  apps/generator-cli/src/app/services/config.service.spec.ts (14.132 s)
 PASS   generator-cli  apps/generator-cli/src/app/app.module.spec.ts (14.273 s)
 PASS   generator-cli  apps/generator-cli/src/app/services/version-manager.service.spec.ts (14.29 s)
 PASS   generator-cli  apps/generator-cli/src/app/services/generator.service.spec.ts (14.305 s)
 PASS   generator-cli  apps/generator-cli/src/app/controllers/version-manager.controller.spec.ts (14.33 s)
 PASS   generator-cli  apps/generator-cli/src/app/services/pass-through.service.spec.ts (14.369 s)

Test Suites: 6 passed, 6 total
Tests:       223 passed, 223 total
Snapshots:   0 total
Time:        16.982 s
Ran all test suites.
```



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make tests cross-platform so they pass on Windows by normalizing paths and classpath handling. All 223 tests now pass on Windows 10.

- **Bug Fixes**
  - Replaced hardcoded POSIX paths with `path.resolve`, `path.join`, and `path.normalize`.
  - Used `path.delimiter` for Java classpath construction.
  - Updated test expectations in generator and version manager specs to compare resolved paths and storage locations.

<sup>Written for commit 88616810ecc256e4535c50505cb151d198e92b57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator-cli/pull/1230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

