### PR TITLE
Nikita korevo test/fix tests for windows

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [windows-latest]
         node-version: [ 22.x ]
 
     steps:
@@ -71,8 +71,8 @@ jobs:
 
       - name: Test
         run: |
-          cd ./examples
-          yarn global add json && export PATH="$(yarn global bin):$PATH"
+          cd examples
+          yarn global add json
           yarn cache clean && yarn add $GITHUB_WORKSPACE/package.tgz
           npm run oa version
           npm run oa completion

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         node-version: [ 22.x ]
 
     steps:

--- a/apps/generator-cli/src/app/services/generator.service.spec.ts
+++ b/apps/generator-cli/src/app/services/generator.service.spec.ts
@@ -1,3 +1,4 @@
+import { delimiter, resolve } from 'path';
 import { Test } from '@nestjs/testing';
 import { GeneratorService } from './generator.service';
 import { LOGGER } from '../constants';
@@ -134,18 +135,18 @@ describe('GeneratorService', () => {
       const cmd = (name, appendix: string[]) => ({
         name,
         command: `java -jar "/path/to/4.2.1.jar" generate ${appendix.join(
-          ' '
+          ' ',
         )}`,
       });
 
       const cmdWithCustomJar = (
         name: string,
         customJar: string,
-        appendix: string[]
+        appendix: string[],
       ) => ({
         name,
-        command: `java -cp "/path/to/4.2.1.jar:${customJar}" org.openapitools.codegen.OpenAPIGenerator generate ${appendix.join(
-          ' '
+        command: `java -cp "/path/to/4.2.1.jar${delimiter}${customJar}" org.openapitools.codegen.OpenAPIGenerator generate ${appendix.join(
+          ' ',
         )}`,
       });
 
@@ -154,25 +155,25 @@ describe('GeneratorService', () => {
           'foo.json',
           [
             cmd('[angular] abc/app/pet.yaml', [
-              `--input-spec="${cwd}/abc/app/pet.yaml"`,
+              `--input-spec="${resolve(cwd, 'abc/app/pet.yaml')}"`,
               `--output="${cwd}/generated-sources/openapi/typescript-angular/pet"`,
               `--generator-name="typescript-angular"`,
               `--additional-properties="fileNaming=kebab-case,apiModulePrefix=Pet,npmName=petRestClient,supportsES6=true,withInterfaces=true"`,
             ]),
             cmd('[angular] abc/app/car.yaml', [
-              `--input-spec="${cwd}/abc/app/car.yaml"`,
+              `--input-spec="${resolve(cwd, 'abc/app/car.yaml')}"`,
               `--output="${cwd}/generated-sources/openapi/typescript-angular/car"`,
               `--generator-name="typescript-angular"`,
               `--additional-properties="fileNaming=kebab-case,apiModulePrefix=Car,npmName=carRestClient,supportsES6=true,withInterfaces=true"`,
             ]),
             cmd('[baz] def/app/pet.yaml', [
-              `--input-spec="${cwd}/def/app/pet.yaml"`,
+              `--input-spec="${resolve(cwd, 'def/app/pet.yaml')}"`,
               `--name="pet"`,
               `--name-uc-first="Pet"`,
               `--cwd="${cwd}"`,
               `--base="pet.yaml"`,
-              `--dir="${cwd}/def/app"`,
-              `--path="${cwd}/def/app/pet.yaml"`,
+              `--dir="${resolve(cwd, 'def/app')}"`,
+              `--path="${resolve(cwd, 'def/app/pet.yaml')}"`,
               `--rel-dir="def/app"`,
               `--rel-path="def/app/pet.yaml"`,
               `--ext="yaml"`,
@@ -180,13 +181,13 @@ describe('GeneratorService', () => {
               '--some-int=1',
             ]),
             cmd('[baz] def/app/car.json', [
-              `--input-spec="${cwd}/def/app/car.json"`,
+              `--input-spec="${resolve(cwd, 'def/app/car.json')}"`,
               `--name="car"`,
               `--name-uc-first="Car"`,
               `--cwd="${cwd}"`,
               `--base="car.json"`,
-              `--dir="${cwd}/def/app"`,
-              `--path="${cwd}/def/app/car.json"`,
+              `--dir="${resolve(cwd, 'def/app')}"`,
+              `--path="${resolve(cwd, 'def/app/car.json')}"`,
               `--rel-dir="def/app"`,
               `--rel-path="def/app/car.json"`,
               `--ext="json"`,
@@ -199,12 +200,12 @@ describe('GeneratorService', () => {
           'bar.json',
           [
             cmd('[bar] api/cat.yaml', [
-              `--input-spec="${cwd}/api/cat.yaml"`,
+              `--input-spec="${resolve(cwd, 'api/cat.yaml')}"`,
               `--output="bar/cat"`,
               '--some-bool',
             ]),
             cmd('[bar] api/bird.json', [
-              `--input-spec="${cwd}/api/bird.json"`,
+              `--input-spec="${resolve(cwd, 'api/bird.json')}"`,
               `--output="bar/bird"`,
               '--some-bool',
             ]),
@@ -214,12 +215,12 @@ describe('GeneratorService', () => {
           'bar.json',
           [
             cmdWithCustomJar('[bar] api/cat.yaml', '../some/custom.jar', [
-              `--input-spec="${cwd}/api/cat.yaml"`,
+              `--input-spec="${resolve(cwd, 'api/cat.yaml')}"`,
               `--output="bar/cat"`,
               '--some-bool',
             ]),
             cmdWithCustomJar('[bar] api/bird.json', '../some/custom.jar', [
-              `--input-spec="${cwd}/api/bird.json"`,
+              `--input-spec="${resolve(cwd, 'api/bird.json')}"`,
               `--output="bar/bird"`,
               '--some-bool',
             ]),
@@ -251,7 +252,7 @@ describe('GeneratorService', () => {
 
         beforeEach(async () => {
           configGet.mockImplementation(
-            (path, defaultValue) => config[filePath] || defaultValue
+            (path, defaultValue) => config[filePath] || defaultValue,
           );
           returnValue = await fixture.generate(customGenerator);
         });
@@ -260,7 +261,7 @@ describe('GeneratorService', () => {
           expect(configGet).toHaveBeenNthCalledWith(
             1,
             'generator-cli.generators',
-            {}
+            {},
           );
         });
 
@@ -296,11 +297,11 @@ describe('GeneratorService', () => {
           expect(executedCommands).toEqual([
             {
               name: '[bar] api/cat.yaml',
-              command: `java -jar "../some/custom.jar" generate --input-spec="${cwd}/api/cat.yaml" --output="bar/cat" --some-bool`,
+              command: `java -jar "../some/custom.jar" generate --input-spec="${resolve(cwd, 'api/cat.yaml')}" --output="bar/cat" --some-bool`,
             },
             {
               name: '[bar] api/bird.json',
-              command: `java -jar "../some/custom.jar" generate --input-spec="${cwd}/api/bird.json" --output="bar/bird" --some-bool`,
+              command: `java -jar "../some/custom.jar" generate --input-spec="${resolve(cwd, 'api/bird.json')}" --output="bar/bird" --some-bool`,
             },
           ]);
         });

--- a/apps/generator-cli/src/app/services/version-manager.service.spec.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.spec.ts
@@ -5,10 +5,9 @@ import { of } from 'rxjs';
 import { LOGGER } from '../constants';
 import chalk from 'chalk';
 import { ConfigService } from './config.service';
-import { resolve } from 'path';
+import { join, normalize, resolve } from 'path';
 import * as os from 'os';
 import { TestingModule } from '@nestjs/testing/testing-module';
-import * as path from 'path';
 
 jest.mock('fs-extra');
 
@@ -328,7 +327,7 @@ describe('VersionManagerService', () => {
       it('removes the correct file', () => {
         expect(fs.removeSync).toHaveBeenNthCalledWith(
           1,
-          `${fixture.storage}/4.3.1.jar`,
+          resolve(fixture.storage, '4.3.1.jar'),
         );
       });
 
@@ -446,7 +445,7 @@ describe('VersionManagerService', () => {
                 before: [chalk.yellow(`Download 4.2.0 ...`)],
                 after: [
                   chalk.green(
-                    `Downloaded 4.2.0 to custom storage location ${expected}`,
+                    `Downloaded 4.2.0 to custom storage location ${resolve(expected)}`,
                   ),
                 ],
               });
@@ -473,22 +472,22 @@ describe('VersionManagerService', () => {
           it('creates a temporary directory', () => {
             expect(fs.mkdtempSync).toHaveBeenNthCalledWith(
               1,
-              path.join(os.tmpdir(), 'generator-cli-'),
+              join(os.tmpdir(), 'generator-cli-'),
             );
           });
 
           it('creates the correct write stream', () => {
             expect(fs.createWriteStream).toHaveBeenNthCalledWith(
               1,
-              '/tmp/generator-cli-abcDEF/4.2.0',
+              normalize('/tmp/generator-cli-abcDEF/4.2.0'),
             );
           });
 
           it('moves the file to the target location', () => {
             expect(fs.moveSync).toHaveBeenNthCalledWith(
               1,
-              '/tmp/generator-cli-abcDEF/4.2.0',
-              `${fixture.storage}/4.2.0.jar`,
+              normalize('/tmp/generator-cli-abcDEF/4.2.0'),
+              resolve(fixture.storage, '4.2.0.jar'),
               { overwrite: true },
             );
           });
@@ -563,7 +562,7 @@ describe('VersionManagerService', () => {
         fixture.isDownloaded('4.3.1');
         expect(fs.existsSync).toHaveBeenNthCalledWith(
           1,
-          fixture.storage + '/4.3.1.jar',
+          resolve(fixture.storage, '4.3.1.jar'),
         );
       });
     });
@@ -571,12 +570,14 @@ describe('VersionManagerService', () => {
     describe('filePath()', () => {
       it('returns the path to the given version name', () => {
         expect(fixture.filePath('1.2.3')).toEqual(
-          `${fixture.storage}/1.2.3.jar`,
+          resolve(fixture.storage, '1.2.3.jar'),
         );
       });
 
       it('returns the path to the selected version name as default', () => {
-        expect(fixture.filePath()).toEqual(`${fixture.storage}/4.3.0.jar`);
+        expect(fixture.filePath()).toEqual(
+          resolve(fixture.storage, '4.3.0.jar'),
+        );
       });
     });
 
@@ -597,7 +598,7 @@ describe('VersionManagerService', () => {
         ])('returns %s for %s', async (expected, cfgValue) => {
           getStorageDir.mockReturnValue(cfgValue);
           await compile();
-          expect(fixture.storage).toEqual(expected);
+          expect(fixture.storage).toEqual(resolve(expected));
         });
       });
     });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix Windows-specific test failures by making path and classpath assertions OS-agnostic. Add a dedicated Windows E2E workflow to catch cross-OS issues.

- **Bug Fixes**
  - Switched tests to use `path.resolve`, `path.join`, `path.normalize`, and `path.delimiter` for expected paths and Java classpaths.
  - Updated Generator and Version Manager specs to resolve `--input-spec`, storage, temp, and move paths; adjusted log outputs to resolved paths.
  - Added a new CI workflow that builds on Ubuntu and runs E2E on `windows-latest` using the packaged tarball.

<sup>Written for commit de7ef5d2fdc4b25319d9c537d2ff8bd76c7664d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator-cli/pull/1233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

