### PR TITLE
chore(fix): sort rows in list command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
           npm run oa help
           npm run oa help generate
           npm run oa version-manager help
+          npm run oa version-manager list
           npm run oa generate -- -g ruby -i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o $GITHUB_WORKSPACE/tmp/ruby-client
           (npm run oa version-manager set 3.0.0 && npm run oa version | grep -q '3.0.0') || exit 1
           (npm run oa version-manager set 6.0 && npm run oa version | grep -q '6.0.1') || exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,6 @@ jobs:
           npm run oa help
           npm run oa help generate
           npm run oa version-manager help
-          npm run oa version-manager list
           npm run oa generate -- -g ruby -i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o $GITHUB_WORKSPACE/tmp/ruby-client
           (npm run oa version-manager set 3.0.0 && npm run oa version | grep -q '3.0.0') || exit 1
           (npm run oa version-manager set 6.0 && npm run oa version | grep -q '6.0.1') || exit 1

--- a/apps/generator-cli/src/app/controllers/version-manager.controller.ts
+++ b/apps/generator-cli/src/app/controllers/version-manager.controller.ts
@@ -95,30 +95,34 @@ export class VersionManagerController {
     );
   };
 
-  private table = (versions: Version[]) =>
-    this.ui.table({
+  private table = (versions: Version[]) => {
+    // Keep row order identical to the order returned in versions.
+    const rows = versions.map((version) => {
+      const stable = version.versionTags.includes('stable');
+      const selected = this.service.isSelectedVersion(version.version);
+      const versionTags = version.versionTags.map((t) =>
+        t === 'latest' ? chalk.green(t) : t,
+      );
+
+      return {
+        value: version,
+        short: version.version,
+        row: {
+          '☐': selected ? '☒' : '☐',
+          releasedAt: version.releaseDate.toISOString().split('T')[0],
+          version: stable
+            ? chalk.yellow(version.version)
+            : chalk.gray(version.version),
+          installed: version.installed ? chalk.green('yes') : chalk.red('no'),
+          versionTags: versionTags.join(' '),
+        },
+      };
+    });
+
+    return this.ui.table({
       printColNum: false,
       message: 'The following releases are available:',
-      rows: versions.map((version) => {
-        const stable = version.versionTags.includes('stable');
-        const selected = this.service.isSelectedVersion(version.version);
-        const versionTags = version.versionTags.map((t) =>
-          t === 'latest' ? chalk.green(t) : t,
-        );
-
-        return {
-          value: version,
-          short: version.version,
-          row: {
-            '☐': selected ? '☒' : '☐',
-            releasedAt: version.releaseDate.toISOString().split('T')[0],
-            version: stable
-              ? chalk.yellow(version.version)
-              : chalk.gray(version.version),
-            installed: version.installed ? chalk.green('yes') : chalk.red('no'),
-            versionTags: versionTags.join(' '),
-          },
-        };
-      }),
+      rows,
     });
+  };
 }

--- a/apps/generator-cli/src/app/services/version-manager.service.spec.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.spec.ts
@@ -189,10 +189,10 @@ describe('VersionManagerService', () => {
 
         it('returns all versions', () => {
           expect(returnValue).toEqual([
-            expectedVersions['4.2.0'],
+            expectedVersions['5.0.0-beta2'],
             expectedVersions['5.0.0-beta'],
             expectedVersions['4.3.1'],
-            expectedVersions['5.0.0-beta2'],
+            expectedVersions['4.2.0'],
             expectedVersions['3.0.0-alpha'],
           ]);
         });
@@ -201,15 +201,15 @@ describe('VersionManagerService', () => {
       describe.each([
         [
           ['beta'],
-          [expectedVersions['5.0.0-beta'], expectedVersions['5.0.0-beta2']],
+          [expectedVersions['5.0.0-beta2'], expectedVersions['5.0.0-beta']],
         ],
         [['beta', 'alpha'], []],
         [
           ['5'],
-          [expectedVersions['5.0.0-beta'], expectedVersions['5.0.0-beta2']],
+          [expectedVersions['5.0.0-beta2'], expectedVersions['5.0.0-beta']],
         ],
         [['4.2'], [expectedVersions['4.2.0']]],
-        [['stable'], [expectedVersions['4.2.0'], expectedVersions['4.3.1']]],
+        [['stable'], [expectedVersions['4.3.1'], expectedVersions['4.2.0']]],
       ])('using tags %s', (tags, expectation) => {
         beforeEach(async () => {
           returnValue = await fixture.search(tags).toPromise();

--- a/apps/generator-cli/src/app/services/version-manager.service.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.ts
@@ -103,7 +103,11 @@ export class VersionManagerService {
 
   search(tags: string[]) {
     return this.getAll().pipe(
-      map((versions) => this.filterVersionsByTags(versions, tags))
+      map((versions) =>
+        [...this.filterVersionsByTags(versions, tags)].sort((l, r) =>
+          compareVersions(r.version, l.version),
+        ),
+      )
     );
   }
 


### PR DESCRIPTION
to close https://github.com/OpenAPITools/openapi-generator-cli/issues/1229

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Sort the list command by semantic version (newest first) and preserve that order when rendering table rows. Updated tests and a CI check (`npm run oa version-manager list`) to verify the ordering.

<sup>Written for commit 4f92c2e26ddd9f0fe7c1f1400dd48ad34e7ca644. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator-cli/pull/1234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

