### PR TITLE
ci: add windows-latest to e2e job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,14 +7,14 @@ on:
       - master
       - renovate/**
   pull_request:
-    types: [ assigned, opened, synchronize, reopened ]
+    types: [assigned, opened, synchronize, reopened]
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 22.x ]
+        node-version: [22.x]
 
     steps:
       - name: Checkout
@@ -48,13 +48,13 @@ jobs:
           path: dist/apps/package.tgz
 
   e2e:
-    name: "E2E local: (${{ matrix.os }})"
+    name: 'E2E local: (${{ matrix.os }})'
     needs: build
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        node-version: [ 22.x ]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: [22.x]
 
     steps:
       - name: Checkout
@@ -69,10 +69,15 @@ jobs:
         with:
           name: package.tgz
 
-      - name: Test
+      - name: set yarn to PATH
+        shell: bash
+        run: echo $(yarn global bin) >> $GITHUB_PATH
+
+      - name: Test (1/2)
+        shell: bash
         run: |
           cd ./examples
-          yarn global add json && export PATH="$(yarn global bin):$PATH"
+          yarn global add json
           yarn cache clean && yarn add $GITHUB_WORKSPACE/package.tgz
           npm run oa version
           npm run oa completion
@@ -84,7 +89,16 @@ jobs:
           (npm run oa version-manager set 6.0 && npm run oa version | grep -q '6.0.1') || exit 1
           (npm run oa version-manager set 4.3.1 && npm run oa version | grep -q '4.3.1') || exit 1
           (npm run oa version-manager set 4.3.1 && npm run oa version | grep -q '4.3.1') || exit 1
-          (export OPENAPI_GENERATOR_CLI_SEARCH_URL=DEFAULT && npm run oa version-manager set 7.2.0 && npm run oa version | grep -q '7.2.0') || exit 1
+
+      - name: set environment variable
+        shell: bash
+        run: echo "OPENAPI_GENERATOR_CLI_SEARCH_URL=DEFAULT" >> $GITHUB_ENV
+
+      - name: Test (2/2)
+        shell: bash
+        run: |
+          cd ./examples
+          (npm run oa version-manager set 7.2.0 && npm run oa version | grep -q '7.2.0') || exit 1
           json -I -f openapitools.json -e 'this["generator-cli"]["storageDir"]="./my/storage/"'
           (npm run oa version-manager set 4.3.0 && npm run oa version | grep -q '4.3.0') || exit 1
           test -f ./my/storage/4.3.0.jar || exit 1
@@ -99,6 +113,7 @@ jobs:
       #    yarn cache clean && yarn add $GITHUB_WORKSPACE/package.tgz
       #    export HTTP_PROXY=http://proxy_ip:proxy_port
       #    npm run oa generate -- -g ruby -i https://raw.githubusercontent.com/OpenAPITools/openapi-generator/master/modules/openapi-generator/src/test/resources/3_0/petstore.yaml -o $GITHUB_WORKSPACE/tmp/ruby-client
+
 #  rel#ease:
 #    if: github.event.pull_request.merged == 'true'
 #    name: Release (Dry)

--- a/apps/generator-cli/src/app/services/config.service.ts
+++ b/apps/generator-cli/src/app/services/config.service.ts
@@ -6,8 +6,7 @@ import { Command } from 'commander';
 
 @Injectable()
 export class ConfigService {
-  public readonly cwd =
-    process.env.PWD || process.env.INIT_CWD || process.cwd();
+  public readonly cwd = process.cwd();
   public readonly configFile = this.configFileOrDefault();
 
   private configFileOrDefault() {


### PR DESCRIPTION
Part of https://github.com/OpenAPITools/openapi-generator-cli/pull/759. I think it is not necessary to separate the e2e job for Windows and Linux with macOS. 

If we don't remove `process.env.PWD || process.env.INIT_CWD`, part of test `cd ./foo && npm run oa:generate` will fail for Windows.

close https://github.com/OpenAPITools/openapi-generator-cli/pull/815,  will be outdated
resolve https://github.com/OpenAPITools/openapi-generator-cli/issues/624, no `process.env.INIT_CWD` no problem
related with https://github.com/OpenAPITools/openapi-generator-cli/issues/690, was discussion about `cwd`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Windows to the E2E CI and make cwd detection OS-agnostic so generator tests run reliably on Windows. Fixes failures in the Windows path flow when running generation commands.

- **Bug Fixes**
  - `generator-cli`: use `process.cwd()` only (drop `PWD`/`INIT_CWD`) to fix Windows path handling during commands like `cd ./foo && npm run oa:generate`.
  - E2E workflow: add `windows-latest`; set Yarn bin to PATH; set `OPENAPI_GENERATOR_CLI_SEARCH_URL` via `$GITHUB_ENV`; split test steps for cross-platform compatibility.

<sup>Written for commit b12cda70c44178b0988ececed41070ecf0c4e7f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator-cli/pull/1237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

