### PR TITLE
feat(release): v7.24.0 release

### DIFF
--- a/apps/generator-cli/src/app/services/version-manager.service.ts
+++ b/apps/generator-cli/src/app/services/version-manager.service.ts
@@ -294,8 +294,15 @@ export class VersionManagerService {
 
   versions : Version[] = [
     {
+      version: '7.24.0',
+      versionTags: [ '7.24.0', 'stable', 'latest' ],
+      releaseDate: new Date("2026-07-20T06:24:58.285Z"),
+      installed: false,
+      downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.24.0/openapi-generator-cli-7.24.0.jar'
+    },
+    {
       version: '7.23.0',
-      versionTags: [ '7.23.0', 'stable', 'latest' ],
+      versionTags: [ '7.23.0', 'stable' ],
       releaseDate: new Date("2026-06-08T06:24:58.285Z"),
       installed: false,
       downloadLink: 'https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/7.23.0/openapi-generator-cli-7.23.0.jar'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added v7.24.0 to the `generator-cli` version list and set it as `latest`. Includes release date and Maven download URL; removed `latest` from v7.23.0.

<sup>Written for commit 0ffc6611c04e19ff0069ff91a79d36ec9aa27afc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator-cli/pull/1259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

