### PR TITLE
chore: stop pinning the concurrently dep to a precise version

### DIFF
--- a/apps/generator-cli/webpack.config.js
+++ b/apps/generator-cli/webpack.config.js
@@ -33,6 +33,7 @@ module.exports = composePlugins(
         'reflect-metadata': '',
         '@nuxtjs/opencollective': '',
         axios: '^',
+        concurrently: '^',
       },
     };
 


### PR DESCRIPTION
Use the recent improvement of https://github.com/lostpebble/generate-package-json-webpack-plugin/pull/49 to propagate a caret version of the concurrently dep in the released package.

Fixes #1248

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish `concurrently` in the generated package with a caret version (^) instead of an exact pin, leveraging the latest `generate-package-json-webpack-plugin` behavior. This allows non-breaking updates to be picked up automatically and fixes #1248.

<sup>Written for commit 88d17eff5157a4dcd5de787aad87476151e52ded. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/OpenAPITools/openapi-generator-cli/pull/1262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

